### PR TITLE
Add locales directory to build.

### DIFF
--- a/spirescope.spec
+++ b/spirescope.spec
@@ -59,6 +59,7 @@ a = Analysis(
         ('sts2/data', 'sts2/data'),
         ('sts2/templates', 'sts2/templates'),
         ('sts2/static', 'sts2/static'),
+        ('sts2/locales', 'sts2/locales'),
     ],
     hiddenimports=[
         'uvicorn.logging',


### PR DESCRIPTION
### Description

Il8n strings and language settings options were not being rendered in frozen builds because the `sts2/locales` directory was not being bundled into the build. This one line change in the PyInstaller spec adds the `sts2/locales` directory into the build.

### Testing

Built on Windows 11 and MacOS 26.4.1 and opened the dashboard to ensure the Il8n strings are properly rendered.

### Related Issues
Fixes thequantumfalcon/spirescope#5