### PR TITLE
Separate user state from shipped data

### DIFF
--- a/sts2/aggregate.py
+++ b/sts2/aggregate.py
@@ -14,13 +14,15 @@ _MIN_IMPORT_CAP = 1000
 
 
 def _aggregate_storage_path() -> Path:
-    """Resolve writable path for aggregate file."""
-    import sys
+    """Resolve writable path for the aggregate file.
 
-    from sts2.config import DATA_DIR
-    if getattr(sys, 'frozen', False):
-        return Path(sys.executable).parent / "community_aggregate.json"
-    return DATA_DIR / "community_aggregate.json"
+    Same location frozen or not: this is user state, and the executable's own
+    directory is not reliably writable (an app installed under /Applications or
+    Program Files is not). Frozen builds that already wrote next to the
+    executable are migrated by config.migrate_state_from_data_dir().
+    """
+    from sts2.config import state_path
+    return state_path("community_aggregate.json")
 
 
 def compute_aggregate_stats(runs: list[RunHistory]) -> dict:

--- a/sts2/app.py
+++ b/sts2/app.py
@@ -19,7 +19,14 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from sts2.analytics import compute_analytics
-from sts2.config import SAVE_DIR, STATIC_DIR, TEMPLATES_DIR, VERSION, ensure_data_dir
+from sts2.config import (
+    SAVE_DIR,
+    STATIC_DIR,
+    TEMPLATES_DIR,
+    VERSION,
+    ensure_data_dir,
+    migrate_state_from_data_dir,
+)
 from sts2.knowledge import KnowledgeBase
 from sts2.saves import get_progress, get_run_history
 
@@ -83,6 +90,12 @@ templates.env.globals["live_js_hash"] = _LIVE_JS_HASH
 
 # Frozen builds: seed the writable data dir from bundled data before loading
 ensure_data_dir()
+# Installs from before the data/state split kept settings, community stats,
+# hypotheses and mods inside the data dir. Move them out once, before anything
+# reads them, so upgrading users keep their data instead of appearing reset.
+_migrated = migrate_state_from_data_dir()
+if _migrated:
+    log.info("Migrated user state out of the data directory: %s", ", ".join(_migrated))
 kb = KnowledgeBase()
 
 _CSRF_SECRET = secrets.token_bytes(32)

--- a/sts2/config.py
+++ b/sts2/config.py
@@ -45,6 +45,95 @@ def ensure_data_dir() -> None:
         logging.getLogger(__name__).error("Failed to seed data dir: %s", exc)
 
 
+def _find_state_dir() -> Path:
+    """Writable directory for state the *user* creates, not shipped data.
+
+    Kept separate from DATA_DIR because the two have opposite lifecycles:
+    DATA_DIR is refreshed wholesale by `sts2 update` and by data-bundle
+    installs, which replace files. Anything of the user's living there is
+    collateral — a bundle install used to discard hand-assigned patch
+    mappings, and in Docker the shipped data dir is not even writable.
+    """
+    env = os.environ.get("STS2_STATE_DIR")
+    if env:
+        return Path(env)
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA") or Path.home() / "AppData" / "Roaming")
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    else:
+        base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return base / "SpireScope"
+
+
+STATE_DIR = _find_state_dir()
+
+# Files that belong to the user rather than to the shipped dataset. Named here
+# so the migration below and the modules that own them cannot drift apart.
+_STATE_FILES = ("settings.json", "community_aggregate.json", "hypotheses.json")
+
+
+def state_path(name: str) -> Path:
+    """Absolute path for a user-state file, creating STATE_DIR on demand."""
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        import logging
+        logging.getLogger(__name__).warning(
+            "Could not create state directory %s", STATE_DIR, exc_info=True)
+    return STATE_DIR / name
+
+
+def migrate_state_from_data_dir() -> list[str]:
+    """Move pre-3.0.3 user state out of the shipped data directory.
+
+    Earlier versions wrote settings, community stats, hypotheses and mods into
+    DATA_DIR. Existing installs must not silently lose them, so move rather
+    than ignore, and never overwrite something already in the new location.
+    Returns the names moved, for logging and tests.
+    """
+    import shutil
+    moved = []
+    # Frozen builds also used to write beside the executable.
+    sources = [DATA_DIR]
+    if getattr(sys, "frozen", False):
+        sources.append(Path(sys.executable).parent)
+    for source in sources:
+        for name in _STATE_FILES:
+            old = source / name
+            new = STATE_DIR / name
+            if not old.exists() or new.exists():
+                continue
+            try:
+                STATE_DIR.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(old), str(new))
+                moved.append(name)
+            except OSError:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Could not migrate %s to %s", name, STATE_DIR, exc_info=True)
+    # mods/ is not purely user state: the package ships it with a README
+    # explaining the format. Move only files the user added, and never the
+    # directory itself, or a source checkout loses a tracked file.
+    old_mods = DATA_DIR / "mods"
+    new_mods = STATE_DIR / "mods"
+    if old_mods.is_dir():
+        for mod_file in sorted(old_mods.iterdir()):
+            if not mod_file.is_file() or mod_file.name == "README.md":
+                continue
+            if (new_mods / mod_file.name).exists():
+                continue
+            try:
+                new_mods.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(mod_file), str(new_mods / mod_file.name))
+                moved.append(f"mods/{mod_file.name}")
+            except OSError:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Could not migrate %s to %s", mod_file.name, new_mods, exc_info=True)
+    return moved
+
+
 TEMPLATES_DIR = PROJECT_ROOT / "templates"
 STATIC_DIR = PROJECT_ROOT / "static"
 
@@ -176,7 +265,9 @@ def _find_mods_dir() -> Path:
         return Path(env)
     if getattr(sys, 'frozen', False):
         return Path(sys.executable).parent / "mods"
-    return DATA_DIR / "mods"
+    # User-authored content, so it lives with the user's state rather than in
+    # the shipped data dir that `sts2 update` replaces wholesale.
+    return STATE_DIR / "mods"
 
 
 def _find_game_dir() -> Path:

--- a/sts2/hypothesis.py
+++ b/sts2/hypothesis.py
@@ -2,15 +2,24 @@
 import json
 import time
 
-from sts2.config import DATA_DIR
+from sts2.config import state_path
 
-HYPOTHESES_FILE = DATA_DIR / "hypotheses.json"
+
+def _hypotheses_file():
+    """Resolved per call, not bound at import.
+
+    A module-level constant would freeze the path before tests or the state
+    migration could redirect it, and it is user-authored data, so it belongs in
+    STATE_DIR rather than the shipped data directory.
+    """
+    return state_path("hypotheses.json")
 
 
 def load_hypotheses():
-    if HYPOTHESES_FILE.exists():
+    path = _hypotheses_file()
+    if path.exists():
         try:
-            return json.loads(HYPOTHESES_FILE.read_text(encoding="utf-8"))
+            return json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
     return {}
@@ -18,7 +27,7 @@ def load_hypotheses():
 
 def save_hypotheses(hypotheses):
     try:
-        HYPOTHESES_FILE.write_text(json.dumps(hypotheses, indent=2), encoding="utf-8")
+        _hypotheses_file().write_text(json.dumps(hypotheses, indent=2), encoding="utf-8")
     except OSError:
         pass
 

--- a/sts2/i18n.py
+++ b/sts2/i18n.py
@@ -67,8 +67,8 @@ def get_translator(code: str = ""):
 
 
 def _settings_path():
-    from sts2.config import DATA_DIR
-    return DATA_DIR / "settings.json"
+    from sts2.config import state_path
+    return state_path("settings.json")
 
 
 def get_language() -> str:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -91,3 +91,77 @@ def test_version_is_consistent_across_release_artifacts():
     assert hardcoded is None, (
         f"spirescope.spec hardcodes VERSION={hardcoded.group(1)!r}; derive it instead")
     assert "config.py" in spec, "spec no longer reads the version from config.py"
+
+
+class TestStateDirSplit:
+    """User state must live outside the shipped data directory.
+
+    DATA_DIR is replaced wholesale by `sts2 update` and by data-bundle
+    installs. Anything of the user's kept there is collateral damage — which is
+    how hand-assigned patch mappings used to be discarded on update.
+    """
+
+    def test_state_dir_is_not_inside_the_package_or_data_dir(self):
+        from sts2.config import BUNDLED_DATA_DIR, DATA_DIR, PROJECT_ROOT, STATE_DIR
+
+        assert PROJECT_ROOT not in STATE_DIR.parents
+        assert BUNDLED_DATA_DIR not in STATE_DIR.parents
+        assert STATE_DIR != DATA_DIR
+
+    def test_user_state_files_resolve_into_state_dir(self, tmp_path, monkeypatch):
+        import sts2.config as cfg
+
+        monkeypatch.setattr(cfg, "STATE_DIR", tmp_path / "state")
+        from sts2.aggregate import _aggregate_storage_path
+        from sts2.hypothesis import _hypotheses_file
+        from sts2.i18n import _settings_path
+
+        for resolver in (_settings_path, _hypotheses_file, _aggregate_storage_path):
+            assert (tmp_path / "state") in resolver().parents, resolver.__name__
+
+    def test_migration_moves_existing_state_without_overwriting(self, tmp_path, monkeypatch):
+        """An upgrading user keeps their stats; a newer file is never clobbered."""
+        import json
+
+        import sts2.config as cfg
+
+        data_dir = tmp_path / "data"
+        state_dir = tmp_path / "state"
+        (data_dir / "mods").mkdir(parents=True)
+        (data_dir / "mods" / "my_mod.json").write_text("{}", encoding="utf-8")
+        # Ships with the package — must survive, or a source checkout loses a
+        # tracked file the first time the app runs.
+        (data_dir / "mods" / "README.md").write_text("mod format docs", encoding="utf-8")
+        (data_dir / "settings.json").write_text('{"language": "en"}', encoding="utf-8")
+        (data_dir / "community_aggregate.json").write_text('{"run_count": 42}', encoding="utf-8")
+        # Already migrated, with different content — must survive untouched.
+        state_dir.mkdir()
+        (state_dir / "hypotheses.json").write_text('{"kept": true}', encoding="utf-8")
+        (data_dir / "hypotheses.json").write_text('{"stale": true}', encoding="utf-8")
+
+        monkeypatch.setattr(cfg, "DATA_DIR", data_dir)
+        monkeypatch.setattr(cfg, "STATE_DIR", state_dir)
+        moved = cfg.migrate_state_from_data_dir()
+
+        assert set(moved) == {"settings.json", "community_aggregate.json", "mods/my_mod.json"}
+        assert json.loads((state_dir / "community_aggregate.json").read_text())["run_count"] == 42
+        assert (state_dir / "mods" / "my_mod.json").exists()
+        assert not (data_dir / "settings.json").exists()
+        # The shipped README stays put and is never copied into user state.
+        assert (data_dir / "mods" / "README.md").exists()
+        assert not (state_dir / "mods" / "README.md").exists()
+        # The pre-existing file wins; the stale copy stays put rather than
+        # silently replacing newer state.
+        assert json.loads((state_dir / "hypotheses.json").read_text()) == {"kept": True}
+
+    def test_migration_is_idempotent(self, tmp_path, monkeypatch):
+        import sts2.config as cfg
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "settings.json").write_text("{}", encoding="utf-8")
+        monkeypatch.setattr(cfg, "DATA_DIR", data_dir)
+        monkeypatch.setattr(cfg, "STATE_DIR", tmp_path / "state")
+
+        assert cfg.migrate_state_from_data_dir() == ["settings.json"]
+        assert cfg.migrate_state_from_data_dir() == []

--- a/tests/test_v3_wireups.py
+++ b/tests/test_v3_wireups.py
@@ -183,7 +183,7 @@ async def test_behavior_invoked_on_analytics_empty_runs(client):
 async def test_hypothesis_crud(client, tmp_path):
     """GET /hypothesis renders; POST create registers; POST delete removes."""
     hyp_file = tmp_path / "hypotheses.json"
-    with patch("sts2.hypothesis.HYPOTHESES_FILE", hyp_file), \
+    with patch("sts2.hypothesis._hypotheses_file", return_value=hyp_file), \
          patch("sts2.app._get_runs", new=AsyncMock(return_value=[])):
         # GET — list page renders.
         resp = await client.get("/hypothesis")


### PR DESCRIPTION
## What this changes

Adds a `STATE_DIR` for user-owned state (settings, community aggregate, hypotheses, mods) so it no longer lives inside `DATA_DIR`, which `sts2 update` and data-bundle installs replace wholesale. Existing installs are migrated on startup.

## Why

One coupling produced several separate defects: a data-bundle install discarded hand-assigned patch mappings, the Docker image could not persist settings because the shipped data dir is root-owned, and release zips carried a runtime `data/` left by the CI smoke test.

## How it was verified

- Simulated an upgrading install: state moves out, survives a full data-dir replacement, shipped dataset untouched.
- Rebuilt the frozen artifact, served all 18 pages, confirmed state is written outside the bundle and no user-state files remain inside it.
- Running the app from a source checkout initially **deleted** the tracked `sts2/data/mods/README.md`, because the first version moved `mods/` wholesale. Caught by running it, not by tests; migration now moves only user-added mod files, with a test pinning that the README stays.

- [x] `pytest -q` passes (728)
- [x] `ruff check sts2/ tests/` passes
- [x] For a bug fix: a new test fails without this change
- [x] Loaded the rendered pages in the packaged build, not just status codes
- [x] No new runtime resource directories added

## Anything reviewers should look at closely

`hypothesis.py` had a module-level path constant that froze at import; it is now resolved per call. The aggregate path no longer special-cases frozen builds — an executable under `/Applications` has no writable directory beside it — and migration covers that old location so existing frozen users keep their stats.