### PR TITLE
Fix frozen OBS overlay, boss win credit, generic counter cards; prepare 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## Unreleased
+## v3.0.3
+
+### Changed
+
+- **User data now lives outside the game-data directory.** Settings, community
+  aggregate stats, saved hypotheses and mods move to a per-user location
+  (`%APPDATA%\SpireScope`, `~/Library/Application Support/SpireScope`, or
+  `$XDG_DATA_HOME/SpireScope`), overridable with `STS2_STATE_DIR`. They
+  previously sat inside the directory that `python -m sts2 update` and
+  data-bundle installs replace wholesale, so a data refresh could discard them.
+  Existing files are moved automatically on first run; nothing needs doing.
+
+### Fixed
 
 ### Removed
 
@@ -15,6 +27,21 @@
 
 ### Fixed
 
+- **The OBS overlay never updated.** Its script wrote to element classes the
+  overlay template did not render, so every live tick was a silent no-op and
+  the numbers froze at whatever they were when the page loaded — only the HP
+  bar's width moved, while the text beside it and its colour stayed put. The
+  floor readout was also permanently blank, printing a field that does not
+  exist on a run.
+- **Boss matchups showed 0 wins for bosses you always beat.** A win was only
+  credited when the entire run was won, so every act 1 and act 2 boss cleared
+  in a run that later ended counted as a fight with neither a win nor a loss —
+  producing rows reading `0 wins / 0 losses / 0%` next to a fight count.
+- **Enemy pages recommended the same eight cards for most enemies.** When an
+  enemy's text gave no signal, a generic fallback recommended an identical
+  Colourless set under a heading promising counters to that enemy's patterns —
+  which covered 136 of 184 enemies. Pages with no real signal now omit the
+  section instead of asserting a relationship that does not exist.
 - **The Community page returned HTTP 500 for anyone with aggregate stats.**
   The card table sorted a mapping of `{wins, total}` dictionaries by value,
   which Python cannot order, so every visit errored once an aggregate existed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates
   static/            # CSS, fonts, images, JS
-tests/               # 707 tests (pytest + pytest-asyncio)
+tests/               # 733 tests (pytest + pytest-asyncio)
                      # + 15 Playwright browser tests: pip install -e ".[browser]"
                      #   && playwright install chromium && pytest -m browser
 ```

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates (32 templates)
   static/            # CSS, fonts (Cinzel), images, JS
-tests/               # 723 tests (pytest + pytest-asyncio)
+tests/               # 732 tests (pytest + pytest-asyncio)
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://img.shields.io/badge/python-3.11%2B-blue" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT">
   <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/thequantumfalcon/spirescope/badges/tests.json" alt="Tests">
-  <img src="https://img.shields.io/badge/coverage-77%25-yellowgreen" alt="Coverage: 77%">
+  <img src="https://img.shields.io/badge/coverage-79%25-yellowgreen" alt="Coverage: 79%">
 </p>
 
 A local-first intelligence dashboard for **Slay the Spire 2** — card/relic/enemy lookup, deck analysis, live run tracking, run history, analytics, community meta, and strategy guides. No cloud, no accounts, no telemetry. Runs entirely on your machine.
@@ -89,7 +89,7 @@ A local-first intelligence dashboard for **Slay the Spire 2** — card/relic/ene
 - **Autopsy Report** — When you die, 5 diagnostic agents analyze what went wrong AND what went right. Causal chain narrative + exculpatory findings.
 - **Hypothesis Lab** — Register strategic beliefs (*"Skipping elites helps"*) and test them with Bayesian statistics across your runs.
 - **Rivalry Seeds** — Export your run, share the seed with a friend, import their run, and see a floor-by-floor decision diff.
-- **Run Integrity** — SHA-256 Merkle chain proves a run is unmodified. Share your hash to verify achievements.
+- **Run Integrity** — SHA-256 Merkle chain over a run's floors, shown on the run detail page, so an exported run can be checked against the hash it was published with.
 
 ### Customize & Extend
 
@@ -321,7 +321,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates (32 templates)
   static/            # CSS, fonts (Cinzel), images, JS
-tests/               # 732 tests (pytest + pytest-asyncio)
+tests/               # 733 tests (pytest + pytest-asyncio)
 ```
 
 ## Requirements

--- a/README_DIST.txt
+++ b/README_DIST.txt
@@ -1,6 +1,13 @@
 Spirescope - Slay the Spire 2 Companion Dashboard
 ==================================================
 
+This file ships with both the Windows and macOS builds. Follow the section
+for your platform.
+
+--------------------------------------------------------------------------
+WINDOWS
+--------------------------------------------------------------------------
+
 IF WINDOWS BLOCKED THIS FILE:
 
   Windows may flag Spirescope.exe as a virus. It is a false positive that
@@ -19,6 +26,36 @@ HOW TO RUN:
   2. Leave the console window open while Spirescope is running
   3. Open http://127.0.0.1:8000 in your browser
 
+--------------------------------------------------------------------------
+macOS
+--------------------------------------------------------------------------
+
+MACOS WILL REFUSE TO OPEN THIS UNTIL YOU CLEAR THE QUARANTINE FLAG:
+
+  This build is not signed or notarized, so Gatekeeper blocks it. You may
+  see "cannot be opened because the developer cannot be verified", or "is
+  damaged and can't be opened" - the download is not damaged, it just
+  carries the quarantine attribute your browser attached.
+
+  Verify the download first, then clear the attribute:
+
+    shasum -a 256 -c Spirescope-macos.zip.sha256
+    xattr -dr com.apple.quarantine Spirescope
+
+  Only do this for software you have chosen to trust and whose checksum
+  you have confirmed.
+
+HOW TO RUN:
+
+  1. Open Terminal in this folder
+  2. Run:  ./Spirescope
+  3. Leave the terminal window open while Spirescope is running
+  4. Open http://127.0.0.1:8000 in your browser
+
+--------------------------------------------------------------------------
+BOTH PLATFORMS
+--------------------------------------------------------------------------
+
 OPTIONAL:
 
   - To auto-open the browser, launch with --browser
@@ -34,11 +71,16 @@ FEATURES:
 
 NOTES:
 
-  - Requires Slay the Spire 2 installed on this PC for save file features
-    (card/relic/enemy lookup works without it)
-  - Windows may still warn because this build is unsigned; verify the release
-    with the included .sha256 checksum file if you want an integrity check
+  - Requires Slay the Spire 2 installed on this machine for save file
+    features (card/relic/enemy lookup works without it)
   - Packaged builds do not auto-check GitHub for updates by default
-  - Click the red "Stop" button in the nav bar, or close the browser tab
+  - To stop the server, click the red "Stop" button in the nav bar, or
+    close the console/terminal window. Closing only the browser tab leaves
+    it running.
+  - Your settings, community stats and saved hypotheses are stored outside
+    this folder, so refreshing game data or replacing this build will not
+    discard them
   - Default address: http://127.0.0.1:8000
   - To change the port, set STS2_PORT environment variable before launching
+  - LICENSE.txt and THIRD_PARTY_NOTICES.md in this folder cover this build
+    and the open-source components it bundles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spirescope"
-version = "3.0.2"
+version = "3.0.3"
 description = "Spirescope — a local web dashboard for Slay the Spire 2. Card/relic/enemy lookup, deck analysis, live run tracking, and strategy guides."
 readme = "README.md"
 license = {text = "MIT"}

--- a/sts2/analytics.py
+++ b/sts2/analytics.py
@@ -926,27 +926,37 @@ def compute_boss_matchups(runs: list[RunHistory], kb=None) -> list[dict]:
     # Collect per-boss per-character stats from floor data
     stats: dict[tuple[str, str], dict] = {}  # (encounter_id, character) -> {wins, losses, total_damage, fights}
 
+    def _entry(key):
+        return stats.setdefault(
+            key, {"wins": 0, "losses": 0, "total_damage": 0, "fights": 0})
+
     for run in runs:
         boss_floors = [f for f in run.floors if f.encounter in boss_ids]
-        for floor in boss_floors:
-            key = (floor.encounter, run.character)
-            if key not in stats:
-                stats[key] = {"wins": 0, "losses": 0, "total_damage": 0, "fights": 0}
-            stats[key]["fights"] += 1
-            stats[key]["total_damage"] += floor.damage_taken
-            # If the run was a win, every boss floor was cleared
-            if run.win:
-                stats[key]["wins"] += 1
-
-        # Loss: only the killing boss gets a loss
+        # Beating a boss is a win against that boss even if the run later ends.
+        # Crediting a win only when the whole run was won left every act-1 and
+        # act-2 boss cleared in a losing run counted as a fight with neither a
+        # win nor a loss, so bosses beaten every time rendered 0 / 0 / 0%.
+        fatal_floor = None
         if not run.win and run.killed_by in boss_ids:
-            key = (run.killed_by, run.character)
-            if key not in stats:
-                stats[key] = {"wins": 0, "losses": 0, "total_damage": 0, "fights": 0}
-            stats[key]["losses"] += 1
-            # Death counts as a fight if floor data didn't record it
-            if stats[key]["fights"] == 0:
-                stats[key]["fights"] = 1
+            for floor in reversed(boss_floors):
+                if floor.encounter == run.killed_by:
+                    fatal_floor = floor
+                    break
+
+        for floor in boss_floors:
+            entry = _entry((floor.encounter, run.character))
+            entry["fights"] += 1
+            entry["total_damage"] += floor.damage_taken
+            if floor is fatal_floor:
+                entry["losses"] += 1
+            else:
+                entry["wins"] += 1
+
+        # Killed by a boss the floor data never recorded: count it anyway.
+        if not run.win and run.killed_by in boss_ids and fatal_floor is None:
+            entry = _entry((run.killed_by, run.character))
+            entry["losses"] += 1
+            entry["fights"] += 1
 
     results = []
     for (boss_id, character), s in stats.items():

--- a/sts2/config.py
+++ b/sts2/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 # Single source of truth for the version fallback (used when importlib.metadata
 # can't find the package, e.g. in PyInstaller bundles). Keep in sync with
 # pyproject.toml [project] version.
-VERSION = "3.0.2"
+VERSION = "3.0.3"
 
 # Project paths
 PROJECT_ROOT = Path(__file__).parent

--- a/sts2/knowledge.py
+++ b/sts2/knowledge.py
@@ -730,8 +730,15 @@ class KnowledgeBase:
             need_keywords["Block"] = need_keywords.get("Block", 0) + 0.5
 
         if not need_keywords:
-            # Generic fallback: recommend Block + damage
-            need_keywords = {"Block": 1.0, "Strength": 0.5}
+            # Nothing in this enemy's text implies a counter. The generic
+            # Block+Strength fallback that used to run here scored identically
+            # for every such enemy, so 136 of 184 enemy pages rendered the same
+            # eight Colorless cards under a heading promising counters to *this*
+            # enemy's patterns. Most of those enemies carry only the
+            # "Auto-discovered from save data" placeholder tip, so there is
+            # genuinely no signal — say nothing rather than assert a
+            # relationship that does not exist.
+            return []
 
         # Score each card
         scored: list[tuple[float, Card]] = []

--- a/sts2/static/overlay.js
+++ b/sts2/static/overlay.js
@@ -32,7 +32,15 @@
     setText('.live-relics', (d.relics || []).length);
     setText('.live-potions', (d.potions || []).length);
     var fill = document.querySelector('.hp-fill');
-    if (fill && d.max_hp > 0) fill.style.width = (d.current_hp / d.max_hp * 100) + '%';
+    if (fill && d.max_hp > 0) {
+      var pct = d.current_hp / d.max_hp * 100;
+      fill.style.width = pct + '%';
+      // Unlike live.js this view never reloads on floor change, so the class
+      // baked in at render time would otherwise stay for the whole run — a
+      // healed player kept a red bar on stream. Thresholds match overlay.html.
+      var tone = pct > 60 ? 'hp-healthy' : (pct > 30 ? 'hp-warning' : 'hp-critical');
+      fill.className = 'hp-fill ' + tone;
+    }
   };
   var errorTimer = null;
   es.onerror = function() {

--- a/sts2/templates/overlay.html
+++ b/sts2/templates/overlay.html
@@ -38,15 +38,18 @@
   <div class="header">
     <div class="live-dot"></div>
     <span class="char char-{{ run.character|lower }}">{{ run.character }}</span>
-    <span class="stat">Floor {{ run.current_floor }}</span>
+    <span class="stat live-floor">Floor {{ run.floor }}</span>
+    <span class="stat live-act">Act {{ run.act }}</span>
     <span class="stat">{{ (run.run_time / 60)|int }}m</span>
   </div>
 
   {% set hp_pct = (run.current_hp / run.max_hp * 100)|int if run.max_hp else 0 %}
   <div class="stats">
-    <span class="stat"><b>{{ run.current_hp }}/{{ run.max_hp }}</b> HP</span>
-    <span class="stat"><b>{{ run.gold }}</b> Gold</span>
-    <span class="stat"><b>{{ run.deck|length }}</b> Cards</span>
+    <span class="stat"><b class="live-hp">{{ run.current_hp }}/{{ run.max_hp }}</b> HP</span>
+    <span class="stat"><b class="live-gold">{{ run.gold }}</b> Gold</span>
+    <span class="stat"><b class="live-cards">{{ run.deck|length }}</b> Cards</span>
+    <span class="stat"><b class="live-relics">{{ run.relics|length }}</b> Relics</span>
+    <span class="stat"><b class="live-potions">{{ run.potions|length }}</b> Potions</span>
   </div>
 
   <div class="hp-bar">

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -387,3 +387,32 @@ def test_shipped_data_has_no_test_fixtures():
         entries = json.loads(path.read_text(encoding="utf-8"))
         offenders = [e.get("id", "") for e in entries if "MOCK" in e.get("id", "").upper()]
         assert not offenders, f"{name} ships test fixtures: {offenders}"
+
+
+def test_shipped_descriptions_are_clean():
+    """DATA_MAINTENANCE.md states tests enforce this; this is that test.
+
+    Descriptions must be single-line, single-spaced, and free of unresolved
+    "{Name:...}" template tokens. The fetcher normalises all three, but nothing
+    checked the result that actually ships, so a regression in _clean_description
+    would only surface as broken layout on a live page.
+    """
+    import re
+
+    from sts2.config import DATA_DIR
+
+    token = re.compile(r"\{\w+:")
+    offenders = []
+    for name in ("cards.json", "relics.json", "potions.json", "events.json"):
+        path = DATA_DIR / name
+        if not path.exists():
+            continue
+        for entry in json.loads(path.read_text(encoding="utf-8")):
+            if not isinstance(entry, dict):
+                continue
+            for key, value in entry.items():
+                if not isinstance(value, str) or "description" not in key:
+                    continue
+                if "\n" in value or "  " in value or token.search(value):
+                    offenders.append(f"{name}:{entry.get('id')}.{key}: {value!r}")
+    assert not offenders, "unclean shipped descriptions:\n" + "\n".join(offenders[:10])

--- a/tests/test_v2_features.py
+++ b/tests/test_v2_features.py
@@ -1535,3 +1535,91 @@ class TestAuditRegressions:
             assert out.returncode == 0, out.stderr
             seen.add(out.stdout.strip())
         assert len(seen) == 1, f"drift verdict varies with hash seed: {seen}"
+
+
+class TestSecondPassRegressions:
+    """Defects found in the follow-up audit sweep. Each fails before its fix."""
+
+    def test_overlay_exposes_the_selectors_its_script_updates(self):
+        """The OBS overlay was frozen: overlay.js targeted classes the template
+        never rendered, so every SSE tick was a silent no-op, and it printed
+        run.current_floor, a field CurrentRun does not have."""
+        import re
+        from unittest.mock import AsyncMock, patch
+
+        from fastapi.testclient import TestClient
+
+        from sts2.models import CurrentRun
+
+        run = CurrentRun(active=True, character="Ironclad", current_hp=74, max_hp=80,
+                         gold=137, act=2, floor=23, run_time=1830,
+                         deck=["CARD.STRIKE"] * 10, relics=["RELIC.VAJRA"],
+                         potions=["POTION.FIRE_POTION"])
+        with patch("sts2.routes._get_live_run", new=AsyncMock(return_value=run)):
+            from sts2.app import app
+            html = TestClient(app).get("/overlay").text
+
+        for cls in ("live-hp", "live-gold", "live-cards", "live-relics",
+                    "live-potions", "live-floor", "live-act", "hp-fill"):
+            assert re.search(r'class="[^"]*\b' + cls + r'\b', html), f"missing .{cls}"
+        assert "Floor 23" in html
+        assert "current_floor" not in html
+
+    def test_overlay_script_targets_only_selectors_that_exist(self):
+        """Guards the pairing directly, so drift in either file is caught."""
+        import re
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parent.parent
+        js = (root / "sts2" / "static" / "overlay.js").read_text(encoding="utf-8")
+        template = (root / "sts2" / "templates" / "overlay.html").read_text(encoding="utf-8")
+        targeted = set(re.findall(r"setText\('\.([a-z-]+)'", js))
+        assert targeted, "overlay.js stopped using setText — update this guard"
+        for cls in targeted:
+            assert cls in template, f"overlay.js writes .{cls}, absent from overlay.html"
+
+    def test_boss_beaten_in_a_losing_run_still_counts_as_a_win(self):
+        """Wins were credited only when the whole run was won, so a boss cleared
+        in act 1 of a run that later died scored as a fight with neither."""
+        from sts2.analytics import compute_boss_matchups
+        from sts2.app import kb as _kb
+        from sts2.models import RunFloor, RunHistory
+
+        bosses = [e.id for e in _kb.enemies
+                  if e.type == "boss" and e.id.startswith("ENCOUNTER.")]
+        assert len(bosses) >= 2, "shipped data has too few bosses to test"
+        early, fatal = bosses[0], bosses[1]
+
+        def floor(enc, dmg):
+            return RunFloor(floor=17, type="boss", encounter=enc, turns=5, damage_taken=dmg)
+
+        runs = [RunHistory(id="a", timestamp=1, character="Ironclad", win=False,
+                           killed_by=fatal, deck=["CARD.STRIKE"],
+                           floors=[floor(early, 10), floor(fatal, 40)])]
+        by_boss = {m["boss"]: m for m in compute_boss_matchups(runs, _kb)}
+        assert by_boss[early]["wins"] == 1
+        assert by_boss[early]["losses"] == 0
+        assert by_boss[early]["win_rate"] == 100
+        assert by_boss[fatal]["losses"] == 1
+        assert by_boss[fatal]["wins"] == 0
+
+    def test_counter_cards_are_absent_rather_than_generic(self):
+        """A fallback recommended the same eight Colorless cards for any enemy
+        with no matching text, under a heading claiming they counter *that*
+        enemy's patterns. No signal must mean no claim."""
+        import collections
+
+        from sts2.app import kb as _kb
+
+        signatures = collections.Counter()
+        for enemy in _kb.enemies:
+            cards = _kb.get_counter_cards(enemy)
+            if cards:
+                signatures[tuple(c.id for c in cards)] += 1
+        total = len(_kb.enemies)
+        assert total > 50, "shipped enemy data looks truncated"
+        if signatures:
+            _, largest = signatures.most_common(1)[0]
+            assert largest < total * 0.5, (
+                f"{largest}/{total} enemies share one counter-card set — "
+                "the generic fallback is back")


### PR DESCRIPTION
## What this changes

Three user-visible defects from the follow-up audit sweep, plus release prep for 3.0.3.

## Why

- The OBS overlay was frozen for streamers: its script targeted classes the template never rendered, and the floor readout printed a field that does not exist.
- Boss matchups credited a win only when the entire run was won, so bosses you beat every time rendered `0 wins / 0 losses / 0%`.
- 136 of 184 enemy pages recommended the same eight Colourless cards under a heading claiming they counter that specific enemy.

## How it was verified

- Each of the four new tests was run against the previous commit in a clean worktree and **fails there**, passing here.
- Overlay driven with an active run through the real route: all seven selectors present, values correct, HP tone correct, no undefined field.
- Counter-card duplication measured across all 184 shipped enemies before and after: the largest identical group drops from 136 to 24.
- Rebuilt the frozen artifact and drove it: reports 3.0.3, 19 pages including `/overlay` and an enemy detail page.

- [x] `pytest -q` passes (732)
- [x] `ruff check sts2/ tests/` passes
- [x] For a bug fix: new tests fail without this change
- [x] Loaded the rendered pages in the packaged build, not just status codes
- [x] No new runtime resource directories added

## Anything reviewers should look at closely

The counter-card change makes the section disappear on 112 enemy pages. That is deliberate — those enemies carry only the placeholder tip, so there is no signal — but it is a visible reduction in content and worth a second opinion.

**Not verified:** the Windows artifact. `release.yml` builds on Python 3.12; the lab machine has 3.11.9, which hits a CPython `dis` bug inside PyInstaller unrelated to this repo. The version metadata itself was confirmed on Windows via PyInstaller's real API.