### PR TITLE
Validate sync redirects and reject non-numeric aggregate counters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates
   static/            # CSS, fonts, images, JS
-tests/               # 733 tests (pytest + pytest-asyncio)
+tests/               # 740 tests (pytest + pytest-asyncio)
                      # + 15 Playwright browser tests: pip install -e ".[browser]"
                      #   && playwright install chromium && pytest -m browser
 ```

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates (32 templates)
   static/            # CSS, fonts (Cinzel), images, JS
-tests/               # 733 tests (pytest + pytest-asyncio)
+tests/               # 740 tests (pytest + pytest-asyncio)
 ```
 
 ## Requirements

--- a/sts2/aggregate.py
+++ b/sts2/aggregate.py
@@ -110,8 +110,45 @@ def _scale_subcounts(d: dict, scale: float) -> dict:
     return out
 
 
+_COUNTER_FIELDS = ("card_pick_rates", "card_win_rates", "relic_win_rates",
+                   "character_stats", "ascension_stats")
+
+
+def _sanitise_import(imported: dict) -> dict:
+    """Drop anything that is not a numeric counter before it can be persisted.
+
+    json.loads succeeding is not validation. A sync server or a hand-crafted
+    /api/import/stats body could put a string, null or nested object where a
+    count belongs; the merge stored it verbatim, and every later read of the
+    community page then failed on it. Accepting bad input is recoverable —
+    persisting it is not, since the bad value outlives the request.
+    """
+    clean: dict = {"run_count": 0}
+    count = imported.get("run_count", 0)
+    if isinstance(count, bool) or not isinstance(count, (int, float)):
+        raise ValueError("run_count must be a number")
+    clean["run_count"] = max(0, int(count))
+
+    for field in _COUNTER_FIELDS:
+        source = imported.get(field)
+        if not isinstance(source, dict):
+            continue
+        kept: dict = {}
+        for key, values in source.items():
+            if not isinstance(key, str) or not isinstance(values, dict):
+                continue
+            numeric = {k: v for k, v in values.items()
+                       if isinstance(k, str) and not isinstance(v, bool)
+                       and isinstance(v, (int, float)) and v >= 0}
+            if numeric:
+                kept[key] = numeric
+        clean[field] = kept
+    return clean
+
+
 def merge_aggregate(existing: dict, imported: dict) -> dict:
     """Weighted merge with anti-manipulation cap."""
+    imported = _sanitise_import(imported)
     if not existing or existing.get("run_count", 0) == 0:
         # Apply min-cap even on first import — prevents a malicious first file
         # from seeding massive bogus stats that then anchor the future cap.

--- a/sts2/sync.py
+++ b/sts2/sync.py
@@ -58,6 +58,10 @@ def _validate_url(url: str) -> str:
             return "multicast"
         if addr.is_unspecified:
             return "unspecified"
+        # Carrier-grade NAT (RFC 6598). ipaddress does not treat it as private,
+        # so 100.64.0.0/10 was reachable despite being non-routable.
+        if addr.version == 4 and addr in ipaddress.ip_network("100.64.0.0/10"):
+            return "carrier-grade NAT"
         return None
 
     # Try parsing hostname as a literal IP first.
@@ -92,6 +96,37 @@ def _validate_url(url: str) -> str:
     return url
 
 
+class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Re-check every redirect hop, and never forward the API key off-origin.
+
+    urlopen() follows 3xx by default and only the originally configured URL was
+    ever validated, so a single Location header voided every check in
+    _validate_url — a sync endpoint could bounce the request into 127.0.0.1,
+    the user's LAN, or cloud metadata. CPython's redirect handler also copies
+    all headers except content-length/content-type, so X-Api-Key travelled to
+    whatever host the redirect named, over cleartext http if it chose.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        _validate_url(newurl)
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new is not None and _origin(newurl) != _origin(req.full_url):
+            new.headers.pop("X-api-key", None)
+            new.headers.pop("X-Api-Key", None)
+        return new
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urllib.parse.urlparse(url)
+    return (parsed.scheme, (parsed.hostname or "").lower(), parsed.port)
+
+
+def _open(req):
+    """Open a request through an opener that validates redirects."""
+    opener = urllib.request.build_opener(_ValidatingRedirectHandler)
+    return opener.open(req, timeout=_TIMEOUT)
+
+
 def _headers() -> dict[str, str]:
     from sts2.config import VERSION
     h = {"Content-Type": "application/json", "User-Agent": f"Spirescope/{VERSION}"}
@@ -113,7 +148,7 @@ def upload_stats(data: dict) -> dict:
 
     req = urllib.request.Request(url, data=payload, headers=_headers(), method="POST")
     try:
-        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        with _open(req) as resp:
             return json.loads(resp.read(_MAX_SIZE))
     except urllib.error.HTTPError as e:
         raise SyncError(f"Server returned {e.code}: {e.reason}") from e
@@ -132,7 +167,7 @@ def download_stats() -> dict:
     url = SYNC_URL.rstrip("/") + "/api/v1/aggregate"
     req = urllib.request.Request(url, headers=_headers(), method="GET")
     try:
-        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        with _open(req) as resp:
             raw = resp.read(_MAX_SIZE + 1)
             if len(raw) > _MAX_SIZE:
                 raise SyncError("Downloaded data too large.")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -30,7 +30,7 @@ class TestUploadStats:
         mock_resp.__exit__ = MagicMock(return_value=False)
 
         with patch("sts2.sync.SYNC_URL", "https://example.com"), \
-             patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+             patch("sts2.sync._open", return_value=mock_resp) as mock_open:
             result = upload_stats({"run_count": 5})
 
         assert result == response_data
@@ -40,14 +40,14 @@ class TestUploadStats:
 
     def test_http_error(self):
         with patch("sts2.sync.SYNC_URL", "https://example.com"), \
-             patch("urllib.request.urlopen",
+             patch("sts2.sync._open",
                    side_effect=HTTPError("url", 500, "Internal Server Error", {}, None)):
             with pytest.raises(SyncError, match="500"):
                 upload_stats({"run_count": 5})
 
     def test_connection_error(self):
         with patch("sts2.sync.SYNC_URL", "https://example.com"), \
-             patch("urllib.request.urlopen",
+             patch("sts2.sync._open",
                    side_effect=URLError("Connection refused")):
             with pytest.raises(SyncError, match="Connection failed"):
                 upload_stats({"run_count": 5})
@@ -69,7 +69,7 @@ class TestDownloadStats:
         mock_resp.__exit__ = MagicMock(return_value=False)
 
         with patch("sts2.sync.SYNC_URL", "https://example.com"), \
-             patch("urllib.request.urlopen", return_value=mock_resp):
+             patch("sts2.sync._open", return_value=mock_resp):
             result = download_stats()
 
         assert result == response_data
@@ -81,7 +81,7 @@ class TestDownloadStats:
         mock_resp.__exit__ = MagicMock(return_value=False)
 
         with patch("sts2.sync.SYNC_URL", "https://example.com"), \
-             patch("urllib.request.urlopen", return_value=mock_resp):
+             patch("sts2.sync._open", return_value=mock_resp):
             with pytest.raises(SyncError, match="Invalid aggregate format"):
                 download_stats()
 
@@ -92,13 +92,13 @@ class TestDownloadStats:
         mock_resp.__exit__ = MagicMock(return_value=False)
 
         with patch("sts2.sync.SYNC_URL", "https://example.com"), \
-             patch("urllib.request.urlopen", return_value=mock_resp):
+             patch("sts2.sync._open", return_value=mock_resp):
             with pytest.raises(SyncError, match="too large"):
                 download_stats()
 
     def test_http_error(self):
         with patch("sts2.sync.SYNC_URL", "https://example.com"), \
-             patch("urllib.request.urlopen",
+             patch("sts2.sync._open",
                    side_effect=HTTPError("url", 404, "Not Found", {}, None)):
             with pytest.raises(SyncError, match="404"):
                 download_stats()
@@ -116,7 +116,7 @@ class TestHeaders:
 
         with patch("sts2.sync.SYNC_URL", "https://example.com"), \
              patch("sts2.sync.SYNC_API_KEY", "secret-key-123"), \
-             patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+             patch("sts2.sync._open", return_value=mock_resp) as mock_open:
             download_stats()
 
         req = mock_open.call_args[0][0]
@@ -131,7 +131,7 @@ class TestHeaders:
 
         with patch("sts2.sync.SYNC_URL", "https://example.com"), \
              patch("sts2.sync.SYNC_API_KEY", ""), \
-             patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+             patch("sts2.sync._open", return_value=mock_resp) as mock_open:
             download_stats()
 
         req = mock_open.call_args[0][0]
@@ -174,3 +174,71 @@ class TestValidateUrl:
         ]):
             with pytest.raises(ValueError, match="private|loopback"):
                 _validate_url("https://evil.example.com/sync")
+
+
+class TestRedirectValidation:
+    """urlopen follows 3xx, and only the configured URL was ever validated —
+    so one Location header voided every check in _validate_url."""
+
+    def _handler(self):
+        from sts2.sync import _ValidatingRedirectHandler
+        return _ValidatingRedirectHandler()
+
+    def _req(self, url="https://sync.example.com/api/v1/aggregate"):
+        import urllib.request
+
+        from sts2.sync import _headers
+        return urllib.request.Request(url, headers=_headers(), method="GET")
+
+    def test_redirect_into_loopback_is_rejected(self):
+        import pytest
+        with pytest.raises(ValueError):
+            self._handler().redirect_request(
+                self._req(), None, 302, "Found", {}, "https://127.0.0.1:8000/health")
+
+    def test_redirect_to_cloud_metadata_is_rejected(self):
+        import pytest
+        with pytest.raises(ValueError):
+            self._handler().redirect_request(
+                self._req(), None, 302, "Found", {},
+                "https://169.254.169.254/latest/meta-data/")
+
+    def test_redirect_to_private_lan_is_rejected(self):
+        import pytest
+        with pytest.raises(ValueError):
+            self._handler().redirect_request(
+                self._req(), None, 302, "Found", {}, "https://192.168.1.1/setup.cgi")
+
+    def test_redirect_downgrade_to_http_is_rejected(self):
+        import pytest
+        with pytest.raises(ValueError):
+            self._handler().redirect_request(
+                self._req(), None, 302, "Found", {}, "http://sync.example.com/x")
+
+    def test_api_key_is_not_forwarded_to_another_origin(self):
+        from unittest.mock import patch
+        with patch("sts2.sync.SYNC_API_KEY", "SECRET-KEY"):
+            req = self._req()
+            assert req.headers.get("X-api-key") == "SECRET-KEY"
+            with patch("sts2.sync._validate_url", return_value="ok"):
+                new = self._handler().redirect_request(
+                    req, None, 302, "Found", {}, "https://other.example.net/x")
+        assert new is not None
+        assert not any(k.lower() == "x-api-key" for k in new.headers)
+
+    def test_api_key_survives_a_same_origin_redirect(self):
+        from unittest.mock import patch
+        with patch("sts2.sync.SYNC_API_KEY", "SECRET-KEY"):
+            req = self._req()
+            with patch("sts2.sync._validate_url", return_value="ok"):
+                new = self._handler().redirect_request(
+                    req, None, 302, "Found", {}, "https://sync.example.com/moved")
+        assert new is not None
+        assert any(k.lower() == "x-api-key" for k in new.headers)
+
+    def test_carrier_grade_nat_is_rejected(self):
+        import pytest
+
+        from sts2.sync import _validate_url
+        with pytest.raises(ValueError):
+            _validate_url("https://100.64.0.1/api")


### PR DESCRIPTION
Two findings from a security sweep of the opt-in sync path. Both require `STS2_SYNC_URL` to be set; the project ships no sync service.

**Redirects bypassed the SSRF allow-check.** `_validate_url` ran once on the configured URL; `urlopen` then followed 3xx without re-checking, so one Location header voided every protection and forwarded `X-Api-Key` to the redirect target. Now validated per hop, with the key dropped cross-origin. Also closes 100.64.0.0/10 (CGNAT), which `ipaddress` does not treat as private.

**Unvalidated aggregate counters were persisted.** A string or null where a count belongs was written to disk, after which the community page failed on every read.

### Honest bounding
The redirect can only be issued by the server the user chose to trust, hop 1 is HTTPS with cert verification so it cannot be injected on the network, and the response never returns to the attacker — the pivot is blind and GET-only. The adversarial verifier downgraded both to LOW, and I agree with that.

- [x] `pytest -q` passes (740)
- [x] `ruff check` passes
- [x] New tests fail without this change
- [x] No new runtime resource directories

### Worth a look
The sync tests were patching `urllib.request.urlopen`, which the new opener bypasses — and which revealed they had been reaching the real network (a live 405 from example.com). They now patch `sts2.sync._open`.