### PR TITLE
Release fixes for v3.0.3: empty HP labels, Windows test env, v0.110.0 manifest

### DIFF
--- a/sts2/data/patches.json
+++ b/sts2/data/patches.json
@@ -117,5 +117,51 @@
       "relics": [],
       "enemies": []
     }
+  },
+  {
+    "patch": "v0.110.0",
+    "date": "2026-07-31",
+    "branch": "beta",
+    "build_ids": [
+      "v0.110.0"
+    ],
+    "changed": {
+      "cards": [
+        "CARD.ABUNDANCE_EVENT",
+        "CARD.RELAX",
+        "CARD.WHISTLE",
+        "CARD.WHISTLE_EVENT",
+        "CARD.MAUL",
+        "CARD.MAUL_EVENT",
+        "CARD.MANGLE",
+        "CARD.PACTS_END",
+        "CARD.HAZE",
+        "CARD.OUTBREAK",
+        "CARD.FOLLOW_THROUGH",
+        "CARD.MIRAGE",
+        "CARD.WELL_LAID_PLANS",
+        "CARD.ECHOING_SLASH",
+        "CARD.TERRAFORMING",
+        "CARD.PILLAR_OF_CREATION",
+        "CARD.CRUSH_UNDER",
+        "CARD.EIDOLON",
+        "CARD.SACRIFICE",
+        "CARD.THE_SCYTHE",
+        "CARD.BIASED_COGNITION",
+        "CARD.REFRACT",
+        "CARD.ROCKET_PUNCH",
+        "CARD.SYNCHRONIZE"
+      ],
+      "relics": [
+        "RELIC.TOASTY_MITTENS",
+        "RELIC.SEAL_OF_GOLD",
+        "RELIC.BEAUTIFUL_BRACELET",
+        "RELIC.FUR_COAT",
+        "RELIC.SIGNET_RING",
+        "RELIC.FIDDLE",
+        "RELIC.REGALITE"
+      ],
+      "enemies": []
+    }
   }
 ]

--- a/sts2/templates/enemies.html
+++ b/sts2/templates/enemies.html
@@ -25,7 +25,7 @@
   <h3>{{ enemy.name }}
     <span class="tag {% if enemy.type == 'boss' %}tag-attack{% elif enemy.type == 'elite' %}tag-power{% else %}tag-skill{% endif %}">{{ enemy.type }}</span>
   </h3>
-  <p>{{ enemy.act|join(', ') }} &bull; HP: {{ enemy.hp_range }}</p>
+  <p>{{ enemy.act|join(', ') }}{% if enemy.hp_range %} &bull; HP: {{ enemy.hp_range }}{% endif %}</p>
   {% if enemy.tips %}<p class="text-sm text-green">{{ enemy.tips[0] }}</p>{% endif %}
 </a>
 {% endfor %}

--- a/sts2/templates/enemy_detail.html
+++ b/sts2/templates/enemy_detail.html
@@ -9,7 +9,7 @@
   <h1>{{ enemy.name }}
     <span class="tag {% if enemy.type == 'boss' %}tag-attack{% elif enemy.type == 'elite' %}tag-power{% else %}tag-skill{% endif %}">{{ enemy.type }}</span>
   </h1>
-  <p class="text-muted">{{ enemy.act|join(', ') }} &bull; HP: {{ enemy.hp_range }}{% if danger %} &bull; Danger: <span class="danger-{{ danger.grade|lower }}">{{ danger.grade }}</span> (avg {{ danger.avg_damage }} dmg, {{ danger.fights }} fights){% endif %}</p>
+  <p class="text-muted">{{ enemy.act|join(', ') }}{% if enemy.hp_range %} &bull; HP: {{ enemy.hp_range }}{% endif %}{% if danger %} &bull; Danger: <span class="danger-{{ danger.grade|lower }}">{{ danger.grade }}</span> (avg {{ danger.avg_damage }} dmg, {{ danger.fights }} fights){% endif %}</p>
 </div>
 
 {% if enemy.patterns %}

--- a/sts2/templates/search.html
+++ b/sts2/templates/search.html
@@ -50,7 +50,7 @@
 {% for enemy in results.enemies %}
 <a href="/enemies/{{ enemy.id }}" class="card card-link">
   <h3>{{ enemy.name }} <span class="tag tag-{{ enemy.type }}">{{ enemy.type }}</span></h3>
-  <p>{{ enemy.act|join(', ') }} &bull; HP: {{ enemy.hp_range }}</p>
+  <p>{{ enemy.act|join(', ') }}{% if enemy.hp_range %} &bull; HP: {{ enemy.hp_range }}{% endif %}</p>
 </a>
 {% endfor %}
 </div>

--- a/tests/test_v2_features.py
+++ b/tests/test_v2_features.py
@@ -1527,11 +1527,17 @@ class TestAuditRegressions:
             "['Alpha','Beta','Gamma','Beta','Gamma','Alpha']];"
             "print(detect_drift_alert(t))"
         )
+        # Windows: Path.home() (hit when sts2.config imports) has no fallback
+        # when USERPROFILE/HOMEDRIVE are stripped, unlike POSIX's pwd lookup.
+        passthrough = {k: os.environ[k]
+                       for k in ("PATH", "SYSTEMROOT", "USERPROFILE",
+                                 "HOMEDRIVE", "HOMEPATH")
+                       if k in os.environ}
         seen = set()
         for seed in ("0", "1", "2", "3", "4"):
             out = subprocess.run([sys.executable, "-c", script],
                                  capture_output=True, text=True,
-                                 env={"PYTHONHASHSEED": seed, "PATH": os.environ.get("PATH", "")})
+                                 env={"PYTHONHASHSEED": seed, **passthrough})
             assert out.returncode == 0, out.stderr
             seen.add(out.stdout.strip())
         assert len(seen) == 1, f"drift verdict varies with hash seed: {seen}"


### PR DESCRIPTION
Validated the v3.0.3 release build end to end on Windows (fresh clone, Python 3.12 build, exe metadata 3.0.3, all four resource folders bundled, zero raw i18n keys in rendered pages, live overlay verified against an active run). Three fixes came out of it:

- Hide the HP label for the 140 of 184 enemies whose hp_range is unknown (enemies list, enemy detail, search results). Aeonglass HP itself remains unknown: wiki.gg and slaythespire2.gg are both behind Cloudflare walls, so no value was invented.
- Fix the Windows-only failure in test_drift_dominant_archetype_is_deterministic: the scrubbed subprocess env broke Path.home() on Windows (POSIX falls back to the pwd database, Windows does not). Home-related env vars are now passed through; hash-seed control is unchanged.
- Add v0.110.0 (2026-07-31, beta) to the patch manifest, sourced from the Steam news API for appid 2868840. 24 card and 7 relic IDs, all validated against the data files. Enemies list intentionally empty: Tough Egg has no enemies.json entry and the Decimillipede change was display-only.

740 tests pass. Rebuilt dist re-verified: analytics reports current patch v0.110.0 and the dangling HP labels are gone.