### PR TITLE
Tell people how to translate card text, now that they can

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A local-first intelligence dashboard for **Slay the Spire 2** — card/relic/ene
 - **Main vs beta awareness** — runs badge their game branch; beta-only content is chipped; filter analytics by branch.
 - **Merged save history** — vanilla and modded save trees merge into one deduplicated history (the game copies saves between them since v0.108.0); runs carry a vanilla/modded origin filter.
 - **Badges** — earned badges with bronze/silver/gold tiers on the Records page.
-- **UI language setting** — switch languages under Settings. The interface ships in fourteen languages (English, Traditional Chinese, German, Spanish, Latin American Spanish, French, Italian, Japanese, Korean, Polish, Brazilian Portuguese, Russian, Thai, Turkish); the twelve newest are drafts pending native review. Entity names and descriptions can be translated too by dropping a `<lang>.json` overlay into `sts2/locales/content/` — search follows the active language, and anything untranslated falls back to English. Locale files live under `sts2/locales/`.
+- **Languages** — switch under Settings. The interface ships in fourteen languages; card, relic and enemy text can be translated too with one command. See [Languages](#languages).
 
 ### Browse & Research
 
@@ -164,6 +164,38 @@ Local builds also write `dist/SHA256SUMS.txt` for checksum verification.
 docker build -t spirescope .
 docker run -p 8000:8000 spirescope
 ```
+
+## Languages
+
+Pick a language under **Settings**. That translates the interface — navigation,
+buttons, labels. It ships in fourteen: English, Traditional Chinese, German,
+Spanish, Latin American Spanish, French, Italian, Japanese, Korean, Polish,
+Brazilian Portuguese, Russian, Thai and Turkish. English and Traditional
+Chinese are reviewed; the other twelve are drafts, and corrections from native
+speakers are welcome.
+
+Card, relic, potion, enemy and event text is separate, because that text
+belongs to the game. To see it in your language, run this once:
+
+```bash
+spirescope localize          # or: python -m sts2 localize
+```
+
+It reads the language files from the copy of Slay the Spire 2 already
+installed on your machine and writes them to `sts2/locales/content/`. Nothing
+is downloaded and nothing is sent anywhere; the game directory is only read
+from, never written to. Restart Spirescope and card text follows your language
+setting, with search matching the translated names.
+
+```bash
+spirescope localize --list          # which languages your install offers
+spirescope localize --lang de,ja    # only these
+```
+
+A standard installation offers thirteen languages besides English. Because the
+text comes from your own install, it stays in step with whatever game version
+you have rather than going stale. Anything the game does not translate — and
+any card added since your installed version — stays in English.
 
 ## Why SpireScope?
 

--- a/sts2/routes.py
+++ b/sts2/routes.py
@@ -1708,11 +1708,14 @@ async def data_update_install(request: Request, csrf_token: str = Form("")):
 
 @router.get("/settings", response_class=HTMLResponse)
 async def settings_page(request: Request):
-    from sts2.i18n import available_languages, get_language
+    from sts2.i18n import available_languages, get_language, load_content_overlay
     a = _app()
+    current = get_language()
     return a.templates.TemplateResponse(request, "settings.html", {
         "languages": available_languages(),
-        "current_language": get_language(),
+        "current_language": current,
+        # Whether card/relic/enemy text is translated too, or only the chrome
+        "content_translated": bool(load_content_overlay(current)),
         "saved": request.query_params.get("saved", ""),
         "csrf_token": a.generate_csrf_token(),
     })

--- a/sts2/templates/settings.html
+++ b/sts2/templates/settings.html
@@ -16,5 +16,11 @@
   </select>
   <button type="submit" class="btn btn-sm">{{ t("settings.save") }}</button>
 </form>
-<p class="text-sm text-muted mt-md">Game data (card and relic text) remains in English until a licensed localized source exists.</p>
+{% if current_language == "en" %}
+<p class="text-sm text-muted mt-md">Card, relic and enemy text is shown in English.</p>
+{% elif content_translated %}
+<p class="text-sm text-muted mt-md">Card, relic and enemy text is translated. Entries the game does not translate stay in English.</p>
+{% else %}
+<p class="text-sm text-muted mt-md">Only the interface is translated. To translate card, relic and enemy text as well, run <code>spirescope localize</code> once — it builds the text from the Slay the Spire 2 files already on your machine.</p>
+{% endif %}
 {% endblock %}

--- a/tests/test_enchantments.py
+++ b/tests/test_enchantments.py
@@ -273,6 +273,26 @@ async def test_settings_language_post_round_trip(client, tmp_path, monkeypatch):
     assert "saved=1" in resp.headers["location"]
 
 
+async def test_settings_tells_you_how_to_translate_game_text(client, monkeypatch):
+    """The page used to state that card text 'remains in English until a
+    licensed localized source exists', which stopped being true when the
+    localize command shipped. A user picking a language needs to be told
+    whether entity text follows, and what to run if it does not."""
+    from sts2 import routes
+
+    monkeypatch.setattr(routes, "_app", routes._app)
+    # chrome-only: no overlay generated for this locale yet
+    monkeypatch.setenv("STS2_LANG", "fr")
+    body = (await client.get("/settings")).text
+    assert "Only the interface is translated" in body
+    assert "spirescope localize" in body
+    # English needs no instructions
+    monkeypatch.setenv("STS2_LANG", "en")
+    body = (await client.get("/settings")).text
+    assert "shown in English" in body
+    assert "spirescope localize" not in body
+
+
 def test_ui_locale_read_failure_is_not_cached(tmp_path, monkeypatch):
     """Same rule as the content overlay: a locked or half-written locale file
     must not pin the UI to English for the life of the process."""


### PR DESCRIPTION
Documentation only. The localize command shipped in 3.0.4 without anywhere useful telling people it exists.

## The settings page was saying the opposite

It still read "Game data (card and relic text) remains in English until a licensed localized source exists" — no longer true as of 3.0.4, and printed on the one screen where somebody choosing a language would read it.

It now reports the actual state of that install: English, or translated, or interface-only with the single command that fixes it. Someone switching to French now sees what to run instead of being told it is impossible.

## The README described the manual path

`localize` appeared only as three lines in the CLI list, and the feature bullet described placing overlay files into a directory by hand rather than the command that generates them. There is now a Languages section covering what the setting does, what the command does, what it reads and does not touch, and which locales are reviewed versus draft.

## Verification

765 tests and ruff clean. The new test was run against the old template first and fails there, so it detects the wording it is meant to protect. All three settings states were also checked against a running server: English, a locale with no overlay generated, and a locale with one.
