### PR TITLE
Ship license notices in release zips, keep runtime state out, close three test gaps

### DIFF
--- a/.github/workflows/no-ai-attribution.yml
+++ b/.github/workflows/no-ai-attribution.yml
@@ -13,6 +13,12 @@ on:
   pull_request:
     branches: ['**']
 
+# This job only checks out and greps, and it runs on every push and every pull
+# request including from forks. State it explicitly rather than inheriting the
+# repository default, which is read today but is a setting that can change.
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: Scan for AI attribution

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -59,6 +59,33 @@ jobs:
           echo "smoke test passed: real strings rendered, key pages 200"
           pkill -f "Spirescope serve" || true
 
+      - name: Stage distribution files
+        # Runs AFTER the smoke test on purpose. Two things this fixes, both
+        # verified missing from the published v3.0.3 and v3.0.4 zips:
+        #
+        # 1. The smoke test runs the app from dist/Spirescope, and a frozen
+        #    build seeds its data dir next to the executable — so a data/
+        #    directory of runtime state was being swept into the release. A
+        #    fresh install re-seeds it from the bundled copy on first run, so
+        #    removing it here is safe and keeps runtime state out of the zip.
+        # 2. "Strip dist-info" above also deletes the bundled packages' LICENSE
+        #    files, and BSD-3-Clause and Apache-2.0 both require the notice to
+        #    accompany a binary redistribution. build.py does this already, but
+        #    this workflow calls PyInstaller directly and never runs build.py.
+        run: |
+          rm -rf dist/Spirescope/data
+          cp LICENSE dist/Spirescope/LICENSE.txt
+          cp THIRD_PARTY_NOTICES.md dist/Spirescope/THIRD_PARTY_NOTICES.md
+          cp README_DIST.txt dist/Spirescope/README.txt
+          for f in LICENSE.txt THIRD_PARTY_NOTICES.md README.txt; do
+            test -f "dist/Spirescope/$f" || { echo "::error::$f missing from the distribution"; exit 1; }
+          done
+          if [ -d dist/Spirescope/data ]; then
+            echo "::error::runtime data/ still present in the distribution"
+            exit 1
+          fi
+          echo "staged: LICENSE.txt, THIRD_PARTY_NOTICES.md, README.txt; runtime data/ removed"
+
       - name: Create zip archive
         run: |
           cd dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,6 @@ jobs:
           Get-ChildItem -Path dist/Spirescope -Recurse -Filter "*.dist-info" -Directory | Remove-Item -Recurse -Force
         shell: pwsh
 
-      - name: Copy distribution README
-        run: |
-          if (Test-Path README_DIST.txt) { Copy-Item README_DIST.txt dist/Spirescope/README.txt }
-        shell: pwsh
-
       - name: Smoke-test the built app
         # Rule: validate the artifact users receive, not just the source tree.
         # Packaging silently drops files the dev env has (issue #5: locales
@@ -61,6 +56,31 @@ jobs:
           Invoke-WebRequest -Uri "http://127.0.0.1:8899/settings" -UseBasicParsing | Out-Null
           Write-Host "smoke test passed: real strings rendered, key pages 200"
           Stop-Process -Id $proc.Id -Force
+        shell: pwsh
+
+      - name: Stage distribution files
+        # Runs AFTER the smoke test on purpose. Two things this fixes, both
+        # verified missing from the published v3.0.3 and v3.0.4 zips:
+        #
+        # 1. The smoke test runs the app from dist/Spirescope, and a frozen
+        #    build seeds its data dir next to the executable — so a data/
+        #    directory of runtime state was being swept into the release. A
+        #    fresh install re-seeds it from the bundled copy on first run, so
+        #    removing it here is safe and keeps runtime state out of the zip.
+        # 2. "Strip dist-info" above also deletes the bundled packages' LICENSE
+        #    files, and BSD-3-Clause and Apache-2.0 both require the notice to
+        #    accompany a binary redistribution. build.py does this already, but
+        #    this workflow calls PyInstaller directly and never runs build.py.
+        run: |
+          if (Test-Path dist/Spirescope/data) { Remove-Item -Recurse -Force dist/Spirescope/data }
+          Copy-Item LICENSE dist/Spirescope/LICENSE.txt
+          Copy-Item THIRD_PARTY_NOTICES.md dist/Spirescope/THIRD_PARTY_NOTICES.md
+          Copy-Item README_DIST.txt dist/Spirescope/README.txt
+          foreach ($f in @("LICENSE.txt","THIRD_PARTY_NOTICES.md","README.txt")) {
+            if (-not (Test-Path "dist/Spirescope/$f")) { throw "$f missing from the distribution" }
+          }
+          if (Test-Path dist/Spirescope/data) { throw "runtime data/ still present in the distribution" }
+          Write-Host "staged: LICENSE.txt, THIRD_PARTY_NOTICES.md, README.txt; runtime data/ removed"
         shell: pwsh
 
       - name: Create zip archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
   (the wiki cannot express these app-curated categories); the merge now
   protects them.
 - **Relic descriptions no longer leak icon markup.** 28 relics scraped from
-  the wiki shipped raw `@CE`-style icon codes ("Gain an additional @CE...");
+  the wiki shipped raw `@CE`-style icon codes ("Gain an additional `@CE`...");
   relic text now gets the same icon rendering as card text ("1 Energy").
 - **Wiki pluralization templates render correctly.** `{{C|sing|plural|2}}`
   picks the indexed form, so "3 Apparitions" no longer degrades to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates
   static/            # CSS, fonts, images, JS
-tests/               # 740 tests (pytest + pytest-asyncio)
+tests/               # 773 tests (pytest + pytest-asyncio)
                      # + 15 Playwright browser tests: pip install -e ".[browser]"
                      #   && playwright install chromium && pytest -m browser
 ```

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates (32 templates)
   static/            # CSS, fonts (Cinzel), images, JS
-tests/               # 740 tests (pytest + pytest-asyncio)
+tests/               # 773 tests (pytest + pytest-asyncio)
 ```
 
 ## Requirements

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2760,3 +2760,45 @@ async def test_shutdown_route_behavior(client):
     # SIGTERM lambda must never have run, even though Timer was scheduled twice.
     assert not mock_kill.called
     assert mock_timer.call_count == 2  # admin-token success + loopback success.
+
+
+async def test_every_state_changing_route_refuses_unauthenticated_requests(client):
+    """No POST/PUT/PATCH/DELETE may act without a CSRF or admin token.
+
+    A route that mutates state without one can be triggered by any web page the
+    user happens to visit — browsers will send cross-site requests to
+    127.0.0.1. This enumerates the routes off the app rather than listing them,
+    so a newly added endpoint is covered automatically instead of being missed.
+    """
+    from sts2.app import app
+
+    mutating = {"POST", "PUT", "PATCH", "DELETE"}
+    found: list[tuple[str, str]] = []
+
+    def walk(container):
+        for route in getattr(container, "routes", None) or []:
+            verbs = (getattr(route, "methods", None) or set()) & mutating
+            if verbs and getattr(route, "path", None):
+                found.extend((route.path, v) for v in sorted(verbs))
+            # include_router() wraps routes in _IncludedRouter, whose .routes is
+            # None — without this the walk finds nothing and passes vacuously.
+            if getattr(route, "original_router", None) is not None:
+                walk(route.original_router)
+            elif hasattr(route, "routes"):
+                walk(route)
+
+    walk(app)
+    assert found, "route enumeration found nothing — the walk is broken, not the app"
+
+    unguarded = []
+    for path, verb in sorted(set(found)):
+        probe = (path.replace("{hyp_id}", "h1").replace("{run_id}", "1")
+                     .replace("{card_id}", "CARD.STRIKE"))
+        if "{" in probe:
+            continue  # unresolved path param; cannot construct a real request
+        resp = await client.request(verb, probe)
+        # 422 means the body shape was rejected before any auth check ran, so it
+        # is not evidence of a guard — but it is also not an accepted mutation.
+        if resp.status_code < 400:
+            unguarded.append(f"{verb} {probe} -> {resp.status_code}")
+    assert not unguarded, "state-changing routes accepted an unauthenticated request: " + ", ".join(unguarded)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -203,3 +203,30 @@ class TestStateDirSplit:
 
         assert cfg.migrate_state_from_data_dir() == ["settings.json"]
         assert cfg.migrate_state_from_data_dir() == []
+
+
+def test_changelog_has_no_bare_at_mentions():
+    """Release notes are generated from CHANGELOG.md by .github/workflows/release.yml,
+    and GitHub auto-links @name in a release body to that account.
+
+    v3.0.4's notes described a data bug involving raw "@CE"-style icon codes.
+    One of the two occurrences was outside backticks, so GitHub linked it to the
+    real, unrelated account github.com/ce, listed them as a contributor on the
+    release page, and notified them. Anything resembling a handle must stay
+    inside code formatting.
+    """
+    import re
+
+    text = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    # Strip the forms GitHub will not turn into an accidental mention:
+    # fenced blocks, inline code, and explicit markdown links — a deliberate
+    # credit like "[@mattkuo]" or "[@mattkuo](https://github.com/mattkuo)" is
+    # exactly what we want to keep.
+    cleaned = re.sub(r"```.*?```", "", text, flags=re.S)
+    cleaned = re.sub(r"`[^`\n]*`", "", cleaned)
+    cleaned = re.sub(r"\[@[A-Za-z][A-Za-z0-9-]*\](\([^)]*\)|:[^\n]*)?", "", cleaned)
+    mentions = re.findall(r"(?<![\w/])@([A-Za-z][A-Za-z0-9-]{0,38})", cleaned)
+    assert not mentions, (
+        "bare @mentions in CHANGELOG.md would be auto-linked in the generated "
+        f"release notes and notify those accounts: {sorted(set(mentions))}. "
+        "Wrap them in backticks.")

--- a/tests/test_v2_features.py
+++ b/tests/test_v2_features.py
@@ -1629,3 +1629,121 @@ class TestSecondPassRegressions:
             assert largest < total * 0.5, (
                 f"{largest}/{total} enemies share one counter-card set — "
                 "the generic fallback is back")
+
+
+class TestAdvancedAnalyticsValues:
+    """Value-level coverage for the seven "Advanced Analytics" modules.
+
+    These were the least-tested code in the repo despite being the headline
+    features: every existing reference was a mock asserting `mock.called`, so
+    all seven could be replaced by constant-returning stubs simultaneously and
+    the suite stayed green. Each test below asserts a computed value and
+    contrasts two different inputs, so a constant return fails.
+    """
+
+    @staticmethod
+    def _floor(n, enc="ENCOUNTER.X", dmg=5, hp=70, gold=100, pick="", turns=3):
+        return RunFloor(floor=n, type="monster", encounter=enc, turns=turns,
+                        damage_taken=dmg, current_hp=hp, max_hp=80, gold=gold,
+                        card_picked=pick)
+
+    @classmethod
+    def _run(cls, rid, win, ts, floors, deck=None, potions=None):
+        return RunHistory(id=rid, timestamp=ts, character="Ironclad", win=win,
+                          ascension=5, run_time=1200, deck=deck or ["CARD.STRIKE"] * 10,
+                          relics=["RELIC.BURNING_BLOOD"], potions=potions or [],
+                          floors=floors)
+
+    def test_graveyard_epitaph_varies_with_the_run(self):
+        from sts2.app import kb as _kb
+        from sts2.graveyard import generate_epitaph
+
+        deep = self._run("a", False, 1, [self._floor(i) for i in range(1, 25)],
+                         deck=["CARD.STRIKE"] * 28)
+        shallow = self._run("b", False, 2, [self._floor(1)], deck=["CARD.STRIKE"] * 10)
+        first, second = generate_epitaph(deep, _kb), generate_epitaph(shallow, _kb)
+        assert first and second
+        assert first != second, "epitaph does not depend on the run"
+
+    def test_tilt_detection_separates_a_slump_from_a_streak(self):
+        from sts2.behavior import detect_tilt
+
+        losing = [self._run(str(i), False, 1700000000 + i * 600,
+                            [self._floor(j) for j in range(1, 5)]) for i in range(6)]
+        winning = [self._run(str(i), True, 1700000000 + i * 600,
+                             [self._floor(j) for j in range(1, 30)]) for i in range(6)]
+        slump, streak = detect_tilt(losing), detect_tilt(winning)
+        assert slump["tilting"] is True
+        assert slump["consecutive_losses"] == 6
+        assert slump["session_avg_floor"] == 4.0
+        assert streak["tilting"] is False
+        assert streak["consecutive_losses"] == 0
+        assert streak["session_avg_floor"] > slump["session_avg_floor"]
+
+    def test_prophecy_win_probability_is_the_empirical_rate(self):
+        from sts2.prophecy import generate_prophecy
+
+        half = [self._run(str(i), i % 2 == 0, 1700000000 + i * 600,
+                          [self._floor(j) for j in range(1, 20)]) for i in range(8)]
+        allwin = [self._run(str(i), True, 1700000000 + i * 600,
+                            [self._floor(j) for j in range(1, 20)]) for i in range(8)]
+        p_half, p_all = generate_prophecy("Ironclad", 5, half), generate_prophecy("Ironclad", 5, allwin)
+        assert p_half["available"] is True
+        assert p_half["sample_size"] == 8
+        assert p_half["win_probability"] == 50.0
+        assert p_all["win_probability"] == 100.0
+
+    def test_ghost_picks_the_better_run_and_signs_the_deltas(self):
+        from sts2.ghost import compute_splits, find_ghost_run
+
+        best = self._run("best", True, 1, [self._floor(i, hp=80, gold=100 + i * 10)
+                                           for i in range(1, 11)])
+        worse = self._run("worse", True, 2, [self._floor(i, hp=50, gold=50)
+                                             for i in range(1, 11)])
+        ghost = find_ghost_run("Ironclad", 5, [best, worse])
+        assert ghost is not None and ghost.id == "best"
+
+        behind = self._run("cur", False, 3, [self._floor(i, hp=60, gold=80)
+                                             for i in range(1, 6)])
+        splits = compute_splits(behind, ghost)
+        assert splits, "no splits computed"
+        assert splits[0]["hp_delta"] == -20
+        assert splits[0]["ahead"] is False
+
+    def test_cascade_contrasts_before_and_after_a_pick(self):
+        from sts2.app import kb as _kb
+        from sts2.cascade import trace_card_impact
+
+        run = self._run("c", False, 4, [self._floor(1, dmg=20, pick="CARD.BASH"),
+                                        self._floor(2, dmg=5), self._floor(3, dmg=5)])
+        impact = trace_card_impact(run, "CARD.BASH", _kb)
+        assert impact["card_id"] == "CARD.BASH"
+        assert impact["picked_floor"] == 1
+        assert impact["floors_survived_after"] == 3
+        assert impact["post_avg_damage"] == 10.0
+
+    def test_drift_trajectory_tracks_every_floor_and_its_pick(self):
+        from sts2.app import kb as _kb
+        from sts2.drift import compute_archetype_drift
+
+        run = self._run("d", False, 5, [self._floor(1, pick="CARD.BASH"),
+                                        self._floor(2), self._floor(3)])
+        trajectory = compute_archetype_drift(run, _kb)
+        assert len(trajectory) == 3
+        assert [t["floor"] for t in trajectory] == [1, 2, 3]
+        assert trajectory[0]["card_added"] == "CARD.BASH"
+        assert trajectory[1]["card_added"] == ""
+
+    def test_spectral_health_scores_a_coherent_deck_above_an_incoherent_one(self):
+        from sts2.app import kb as _kb
+        from sts2.spectral import deck_spectral_health
+
+        coherent = [c.id for c in _kb.cards if "Block" in (c.keywords or [])][:6]
+        orphans = [c.id for c in _kb.cards if not c.keywords][:5]
+        seed = [c.id for c in _kb.cards if c.keywords][:1]
+        assert len(coherent) == 6 and len(orphans) == 5, "shipped data changed shape"
+        good = deck_spectral_health(coherent, _kb)
+        bad = deck_spectral_health(seed + orphans, _kb)
+        assert good["health_score"] > bad["health_score"]
+        assert good["orphans"] == []
+        assert bad["orphans"], "orphan detection found nothing in a deck of unlinked cards"


### PR DESCRIPTION
Found by unzipping and running the **published v3.0.4 macOS asset**, not a local build — which is precisely how the first item had escaped notice.

## Release packaging

- **Zips shipped without `LICENSE.txt` or `THIRD_PARTY_NOTICES.md`.** `build.py` copies them, but neither release workflow calls `build.py` — both invoke PyInstaller directly and strip `dist-info` themselves, which also deletes the bundled packages' own LICENSE files. BSD-3-Clause and Apache-2.0 require the notice to travel with a binary redistribution; v3.0.3 and v3.0.4 both went out without them.
- **Zips also carried a runtime `data/` directory** — the smoke test runs the app from `dist/Spirescope`, and a frozen build seeds its data dir beside the executable.

Both verified by running the workflow steps locally end to end: build → strip → smoke-test → stage → zip → checksum → unzip → launch. A fresh install re-seeds `data/` from the bundle and serves its pages.

## The @CE mention

`CHANGELOG.md` had a bare `@CE` while describing raw icon codes leaking into relic text. Release notes are generated from that file, and GitHub auto-links a bare `@name` — so the v3.0.4 release linked to the real, unrelated account `github.com/ce`, listed them as a contributor, and notified them. Published notes already corrected; a test now rejects bare mentions.

The guard deliberately still permits the markdown-link form, so the credit to `[@mattkuo]` for fixing #5 is untouched.

## Test gaps

- **Route guard:** enumerates every state-changing route off the app and asserts each refuses an unauthenticated request. Confirmed it bites by registering a deliberately unguarded POST route. The enumeration asserts it found routes at all — FastAPI wraps included routes in `_IncludedRouter` whose `.routes` is `None`, so a naive walk passes vacuously. That happened on my first attempt.
- **Advanced analytics:** every prior reference was a mock asserting `mock.called`, so all seven modules could be stubbed with the suite green. Verified by stubbing each in turn — before: all seven survived; now: all seven caught.

- [x] `pytest -q` passes (773)
- [x] `ruff check` passes
- [x] New tests fail without their fixes
- [x] Exercised the packaged artifact, not just status codes