### PR TITLE
Fill Aeonglass HP and fix the enemy HP field-name split

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates
   static/            # CSS, fonts, images, JS
-tests/               # 773 tests (pytest + pytest-asyncio)
+tests/               # 774 tests (pytest + pytest-asyncio)
                      # + 15 Playwright browser tests: pip install -e ".[browser]"
                      #   && playwright install chromium && pytest -m browser
 ```

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates (32 templates)
   static/            # CSS, fonts (Cinzel), images, JS
-tests/               # 773 tests (pytest + pytest-asyncio)
+tests/               # 774 tests (pytest + pytest-asyncio)
 ```
 
 ## Requirements

--- a/sts2/data/enemies.json
+++ b/sts2/data/enemies.json
@@ -6,7 +6,7 @@
       "Act 3"
     ],
     "type": "boss",
-    "hp_range": "",
+    "hp_range": "512",
     "patterns": [
       "Applies Wither status and Withering Presence power; moveset balanced across characters (per 0.106.0)."
     ],
@@ -472,14 +472,14 @@
     "id": "MONSTER.DECIMILLIPEDE",
     "name": "Decimillipede",
     "type": "elite",
-    "hp": "",
     "description": "",
     "tips": [
       "Elite with three segments (40-46 HP each). All three moves are always in play \u2014 one per segment. When a segment dies, it revives with 25 HP if another segment lives. Strong AoE check; kill all segments before Reattach triggers."
     ],
     "act": [
       "Act 2"
-    ]
+    ],
+    "hp_range": "40-46"
   },
   {
     "id": "ENCOUNTER.DECIMILLIPEDE_ELITE",
@@ -2226,14 +2226,14 @@
     "id": "MONSTER.TOADPOLES",
     "name": "Toadpoles",
     "type": "normal",
-    "hp": "",
     "description": "",
     "tips": [
       "Normal enemy in Act 1 Underdocks (21-25 HP each). Cycle: Whirl (7 dmg), Spiken (gains 2 Thorns), Spike Spit (3x3 dmg). Watch for Thorns \u2014 time attacks to avoid hitting into Spiken turns."
     ],
     "act": [
       "Act 1"
-    ]
+    ],
+    "hp_range": ""
   },
   {
     "id": "ENCOUNTER.TOADPOLES_NORMAL",

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -525,3 +525,15 @@ def test_shipped_descriptions_are_clean():
                 if "\n" in value or "  " in value or token.search(value):
                     offenders.append(f"{name}:{entry.get('id')}.{key}: {value!r}")
     assert not offenders, "unclean shipped descriptions:\n" + "\n".join(offenders[:10])
+
+
+def test_enemy_hp_uses_one_field_name():
+    """Every template reads `hp_range`; two entries carried `hp` instead, so
+    any value in them could never render. Keep the schema single-valued."""
+    from sts2.config import DATA_DIR
+
+    entries = json.loads((DATA_DIR / "enemies.json").read_text(encoding="utf-8"))
+    stray = [e.get("id") for e in entries if "hp" in e]
+    assert not stray, f"entries use 'hp' instead of 'hp_range': {stray}"
+    missing_field = [e.get("id") for e in entries if "hp_range" not in e]
+    assert not missing_field, f"entries have no hp_range field at all: {missing_field}"


### PR DESCRIPTION
## What this changes

Aeonglass now has HP (512), and the two entries that stored it under `hp` instead of `hp_range` are normalised.

## Why

The previous attempt recorded wiki.gg as 401 and slaythespire2.gg as 403. **Both answer 200 today** — that was transient, and the MediaWiki API returns the value directly rather than needing a page scrape.

Separately, every template reads `enemy.hp_range`, but two entries carried `hp`. Decimillipede was one of them, so filling its value also required the rename — otherwise the number would have been stored and never displayed.

## Scope, honestly

**138 of 184 enemies still have no HP, and this does not fix that.** I queried the wiki for all 140 missing names; only these two resolved. The rest have no wiki page at all — confirmed by search, not by a failed title guess. They are either app-side `ENCOUNTER.*` groupings that were never wiki entities, or monsters the wiki has not covered for an early-access game. Filling those needs a source that has them.

- [x] `pytest -q` passes (774)
- [x] `ruff check` passes
- [x] New schema test fails without the rename
- [x] Verified the values render through KnowledgeBase