### PR TITLE
Prepare v3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v3.0.5
+
+### Fixed
+
+- **Release downloads now include the license notices.** The zips shipped
+  without `LICENSE.txt` or `THIRD_PARTY_NOTICES.md`. The build script copies
+  them, but the release workflows never called it — they invoke PyInstaller
+  directly and strip package metadata themselves, which also removes the
+  bundled libraries' own licence files. BSD-3-Clause and Apache-2.0 both
+  require the notice to travel with a binary, so v3.0.3 and v3.0.4 went out
+  without them. The workflows now stage the notices and fail rather than
+  publish without them.
+- **Release downloads no longer carry a stray `data` folder.** The build's
+  own smoke test starts the app, which seeds a data directory beside the
+  executable, and that runtime state was being swept into the archive. A fresh
+  install re-creates it from the bundled copy on first run.
+- **Aeonglass has its HP.** The value was missing because the wiki was
+  unreachable when the entry was last touched; it is 512. Two enemies also
+  stored HP under a field name nothing reads, so their values could never have
+  displayed — Decimillipede now shows 40-46.
+- **Release notes no longer link an unrelated GitHub account.** The v3.0.4
+  notes described raw `@CE`-style icon codes in relic text, and one mention sat
+  outside code formatting, so it was auto-linked to a real user with no
+  connection to this project. The published notes are corrected and the
+  changelog can no longer reintroduce it.
+
+### Internal
+
+- Value-level tests for the seven advanced-analytics modules, which previously
+  could all be replaced with stubs while the suite stayed green.
+- A guard asserting every state-changing route refuses an unauthenticated
+  request, so a newly added endpoint is covered automatically.
+- The attribution-scanning workflow declares read-only permissions.
+
 ## v3.0.4
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spirescope"
-version = "3.0.4"
+version = "3.0.5"
 description = "Spirescope — a local web dashboard for Slay the Spire 2. Card/relic/enemy lookup, deck analysis, live run tracking, and strategy guides."
 readme = "README.md"
 license = {text = "MIT"}

--- a/sts2/config.py
+++ b/sts2/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 # Single source of truth for the version fallback (used when importlib.metadata
 # can't find the package, e.g. in PyInstaller bundles). Keep in sync with
 # pyproject.toml [project] version.
-VERSION = "3.0.4"
+VERSION = "3.0.5"
 
 # Project paths
 PROJECT_ROOT = Path(__file__).parent


### PR DESCRIPTION
Version bump and changelog for everything landed since v3.0.4.

## What's in the release

- Licence notices now ship inside the release zips (they were missing from v3.0.3 and v3.0.4)
- The stray runtime `data/` directory is kept out of the archive
- Aeonglass has its HP (512), and two enemies that stored HP under a field nothing reads are normalised
- The v3.0.4 release notes no longer auto-link an unrelated GitHub account, and the changelog can't reintroduce it

## How it was verified

Replayed the release workflow steps end to end rather than trusting the source tree — build → strip metadata → smoke test → stage notices → zip → checksum → unzip → launch.

The packaged artifact reports **3.0.5**, serves **20 pages**, renders **Aeonglass at HP 512**, leaks **zero** raw translation keys, ships **both** notice files, and contains **no** runtime `data/`.

- [x] `pytest -q` passes (774)
- [x] `ruff check` passes
- [x] Exercised the packaged artifact, not just status codes
- [x] No new runtime resource directories

## Not done here

**The tag.** Publishing is deliberate and separate, and the Windows artifact still needs its own pass on a Windows machine before release.