### PR TITLE
Show playtime as hours and minutes instead of a raw minute count

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates
   static/            # CSS, fonts, images, JS
-tests/               # 774 tests (pytest + pytest-asyncio)
+tests/               # 776 tests (pytest + pytest-asyncio)
                      # + 15 Playwright browser tests: pip install -e ".[browser]"
                      #   && playwright install chromium && pytest -m browser
 ```

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates (32 templates)
   static/            # CSS, fonts (Cinzel), images, JS
-tests/               # 774 tests (pytest + pytest-asyncio)
+tests/               # 776 tests (pytest + pytest-asyncio)
 ```
 
 ## Requirements

--- a/sts2/app.py
+++ b/sts2/app.py
@@ -79,6 +79,27 @@ from sts2.i18n import get_language, get_translator  # noqa: E402
 
 templates.env.globals["t"] = get_translator(get_language())
 templates.env.globals["changed_in"] = _patches.changed_in
+
+
+def _format_playtime(seconds) -> str:
+    """Seconds -> "53h 40m", the way Steam presents playtime.
+
+    The dashboard used to divide by 60 and print the result with an "m"
+    suffix, so a 53-hour save read "3220m". That is the same quantity Steam
+    shows as roughly 54 hours, but nobody performs that division at a glance,
+    and it reads as though the two disagree.
+    """
+    try:
+        total = int(seconds or 0)
+    except (TypeError, ValueError):
+        return "0m"
+    if total < 0:
+        total = 0
+    hours, minutes = divmod(total // 60, 60)
+    return f"{hours}h {minutes}m" if hours else f"{minutes}m"
+
+
+templates.env.filters["playtime"] = _format_playtime
 templates.env.globals["current_patch_name"] = (
     lambda: (_patches.current_patch() or {}).get("patch", "")
 )

--- a/sts2/templates/index.html
+++ b/sts2/templates/index.html
@@ -37,7 +37,7 @@
   <div class="stat-box"><div class="num">{{ total_potions }}</div><div class="label">Potions</div></div>
   <div class="stat-box"><div class="num">{{ total_enemies }}</div><div class="label">Enemies</div></div>
   {% if progress %}
-  <div class="stat-box"><div class="num">{{ (progress.total_playtime / 60)|int }}m</div><div class="label">Playtime</div></div>
+  <div class="stat-box" title="From the game's own playtime counter in your save. Steam measures how long the application was open, including menus and idle time, so Steam usually reads higher."><div class="num">{{ progress.total_playtime|playtime }}</div><div class="label">Playtime</div></div>
   <div class="stat-box"><div class="num">{{ progress.discovered_cards|length }}</div><div class="label">Cards Seen</div></div>
   {% endif %}
   {% if current_streak and current_streak > 1 %}
@@ -64,7 +64,7 @@
     <h3 class="char-{{ char|lower }}">{{ char }}</h3>
     {% if progress and progress.character_stats.get(char) %}
     {% set cs = progress.character_stats[char] %}
-    <p>{{ cs.wins }}W / {{ cs.losses }}L &bull; {{ (cs.playtime / 60)|int }}m played</p>
+    <p>{{ cs.wins }}W / {{ cs.losses }}L &bull; {{ cs.playtime|playtime }} played</p>
     {% if cs.best_streak %}<p class="text-sm text-muted">Best streak: {{ cs.best_streak }}{% if cs.current_streak %} (current: {{ cs.current_streak }}){% endif %}</p>{% endif %}
     {% if cs.max_ascension %}<p class="text-sm text-muted">Max ascension: {{ cs.max_ascension }}</p>{% endif %}
     {% if cs.fastest_win and cs.fastest_win > 0 %}<p class="text-sm text-muted">Fastest win: {{ (cs.fastest_win / 60)|int }}m</p>{% endif %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2802,3 +2802,34 @@ async def test_every_state_changing_route_refuses_unauthenticated_requests(clien
         if resp.status_code < 400:
             unguarded.append(f"{verb} {probe} -> {resp.status_code}")
     assert not unguarded, "state-changing routes accepted an unauthenticated request: " + ", ".join(unguarded)
+
+
+def test_playtime_filter_reads_like_steam():
+    """Playtime came from the save in seconds, was divided by 60, and printed
+    with an "m" suffix — so a 53-hour save rendered "3220m". That is the same
+    quantity Steam shows as ~54 hours, but it reads as a disagreement.
+    """
+    from sts2.app import _format_playtime
+
+    assert _format_playtime(193235) == "53h 40m"   # the real save that prompted this
+    assert _format_playtime(3600) == "1h 0m"
+    assert _format_playtime(90) == "1m"            # under an hour: no "0h" prefix
+    assert _format_playtime(0) == "0m"
+    # Never raise on a missing or malformed counter.
+    assert _format_playtime(None) == "0m"
+    assert _format_playtime("nonsense") == "0m"
+    assert _format_playtime(-5) == "0m"
+
+
+async def test_dashboard_renders_playtime_in_hours(client):
+    """End-to-end: the tile must not show a bare minute count again."""
+    import re
+    from unittest.mock import AsyncMock, patch
+
+    from sts2.models import PlayerProgress
+
+    progress = PlayerProgress(total_playtime=193235)
+    with patch("sts2.app._get_progress", new=AsyncMock(return_value=progress)):
+        html = (await client.get("/")).text
+    assert "53h 40m" in html
+    assert not re.search(r">\s*3220m\s*<", html)


### PR DESCRIPTION
Reported by a player comparing the dashboard against Steam.

## The cause

The numbers were never wrong — they were unreadable. `total_playtime` comes out of the save in **seconds**; the template divided by 60 and printed an `m` suffix. A real 53-hour save rendered:

- **before:** `3220m` on the home page, `2756m played` per character
- **after:** `53h 40m`, `45h 56m played`

Steam shows that same quantity as roughly 54 hours. Nobody performs that division at a glance, so the two looked like they disagreed.

## The part that is still expected

They will not match exactly. This reads **the game's own counter** from the save; Steam measures **how long the application was open**, including menus and idle time, so Steam normally reads higher. The tile now says so on hover rather than leaving it a mystery.

- [x] `pytest -q` passes
- [x] `ruff check` passes
- [x] New tests fail without the change
- [x] Verified against the real save that prompted the report (193,235 s → `53h 40m`)