### PR TITLE
Fix startup crash on malformed mods, WCAG contrast, patch-mapping loss, and keyword orphans

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -28,6 +28,23 @@ jobs:
       - name: Run tests
         run: pytest -q --tb=short
 
+      - name: Verify the tag matches the version in the tree
+        # Four releases (v2.9.4-v2.9.7) shipped binaries whose reported version
+        # did not match their tag. Fail before building rather than publish a
+        # mislabelled artifact.
+        run: |
+          import os, re, sys
+          tag = os.environ["TAG"].lstrip("v")
+          src = open("sts2/config.py", encoding="utf-8").read()
+          version = re.search(r'^VERSION\s*=\s*"([^"]+)"', src, re.M).group(1)
+          if tag != version:
+              print(f"::error::tag {os.environ['TAG']} does not match VERSION {version} in sts2/config.py")
+              sys.exit(1)
+          print(f"tag and VERSION agree: {version}")
+        shell: python
+        env:
+          TAG: ${{ github.ref_name }}
+
       - name: Build macOS app
         run: python -m PyInstaller spirescope.spec --clean --noconfirm
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,23 @@ jobs:
       - name: Run tests
         run: pytest -q --tb=short
 
+      - name: Verify the tag matches the version in the tree
+        # Four releases (v2.9.4-v2.9.7) shipped binaries whose reported version
+        # did not match their tag. Fail before building rather than publish a
+        # mislabelled artifact.
+        run: |
+          import os, re, sys
+          tag = os.environ["TAG"].lstrip("v")
+          src = open("sts2/config.py", encoding="utf-8").read()
+          version = re.search(r'^VERSION\s*=\s*"([^"]+)"', src, re.M).group(1)
+          if tag != version:
+              print(f"::error::tag {os.environ['TAG']} does not match VERSION {version} in sts2/config.py")
+              sys.exit(1)
+          print(f"tag and VERSION agree: {version}")
+        shell: python
+        env:
+          TAG: ${{ github.ref_name }}
+
       - name: Build executable
         run: python -m PyInstaller spirescope.spec --clean --noconfirm
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates
   static/            # CSS, fonts, images, JS
-tests/               # 776 tests (pytest + pytest-asyncio)
+tests/               # 780 tests (pytest + pytest-asyncio)
                      # + 15 Playwright browser tests: pip install -e ".[browser]"
                      #   && playwright install chromium && pytest -m browser
 ```

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ sts2/
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates (32 templates)
   static/            # CSS, fonts (Cinzel), images, JS
-tests/               # 776 tests (pytest + pytest-asyncio)
+tests/               # 780 tests (pytest + pytest-asyncio)
 ```
 
 ## Requirements

--- a/sts2/data/cards.json
+++ b/sts2/data/cards.json
@@ -33,7 +33,11 @@
     "cost": "2",
     "type": "Skill",
     "rarity": "Ancient",
-    "description": "Innate. Upgrade ALL your cards. Exhaust."
+    "description": "Innate. Upgrade ALL your cards. Exhaust.",
+    "keywords": [
+      "Exhaust",
+      "Innate"
+    ]
   },
   {
     "id": "CARD.APPARITION",
@@ -42,7 +46,12 @@
     "cost": "1",
     "type": "Skill",
     "rarity": "Ancient",
-    "description": "Ethereal. Gain 1 Intangible. Exhaust."
+    "description": "Ethereal. Gain 1 Intangible. Exhaust.",
+    "keywords": [
+      "Exhaust",
+      "Ethereal",
+      "Intangible"
+    ]
   },
   {
     "id": "CARD.AUTOMATION",
@@ -238,7 +247,9 @@
     "rarity": "Event",
     "description": "Reduce the cost of ALL cards in your Hand to 1 this turn. Exhaust.",
     "description_upgraded": "",
-    "keywords": []
+    "keywords": [
+      "Exhaust"
+    ]
   },
   {
     "id": "CARD.ENTROPY",
@@ -305,7 +316,10 @@
     "cost": "0",
     "type": "Skill",
     "rarity": "Event",
-    "description": "Gain 5 Strength this turn."
+    "description": "Gain 5 Strength this turn.",
+    "keywords": [
+      "Strength"
+    ]
   },
   {
     "id": "CARD.FINESSE",
@@ -457,7 +471,9 @@
     "rarity": "Common",
     "description": "Deal 6 damage. Apply 2 Poison.",
     "description_upgraded": "",
-    "keywords": []
+    "keywords": [
+      "Poison"
+    ]
   },
   {
     "id": "CARD.IMPATIENCE",
@@ -630,7 +646,10 @@
     "cost": "Unplayable",
     "type": "Status",
     "rarity": "Status",
-    "description": "Draw 1 fewer card each turn."
+    "description": "Draw 1 fewer card each turn.",
+    "keywords": [
+      "Draw"
+    ]
   },
   {
     "id": "CARD.MINION_DIVE_BOMB",
@@ -639,7 +658,10 @@
     "cost": "1",
     "type": "Attack",
     "rarity": "Token",
-    "description": "Deal 13 damage. Exhaust."
+    "description": "Deal 13 damage. Exhaust.",
+    "keywords": [
+      "Exhaust"
+    ]
   },
   {
     "id": "CARD.MINION_SACRIFICE",
@@ -648,7 +670,11 @@
     "cost": "0",
     "type": "Skill",
     "rarity": "Token",
-    "description": "Gain 9 Block. Exhaust."
+    "description": "Gain 9 Block. Exhaust.",
+    "keywords": [
+      "Block",
+      "Exhaust"
+    ]
   },
   {
     "id": "CARD.MINION_STRIKE",
@@ -657,7 +683,11 @@
     "cost": "0",
     "type": "Attack",
     "rarity": "Token",
-    "description": "Deal 7 damage. Draw 1 card. Exhaust."
+    "description": "Deal 7 damage. Draw 1 card. Exhaust.",
+    "keywords": [
+      "Exhaust",
+      "Draw"
+    ]
   },
   {
     "id": "CARD.NOSTALGIA",
@@ -973,7 +1003,9 @@
     "rarity": "Event",
     "energy": "",
     "description": "Deal 10 damage. Apply 2 Vulnerable.",
-    "keywords": [],
+    "keywords": [
+      "Vulnerable"
+    ],
     "cost": "1"
   },
   {
@@ -996,7 +1028,11 @@
     "cost": "0",
     "type": "Attack",
     "rarity": "Token",
-    "description": "Ethereal. Osty deals 10 damage to a random enemy. Exhaust."
+    "description": "Ethereal. Osty deals 10 damage to a random enemy. Exhaust.",
+    "keywords": [
+      "Exhaust",
+      "Ethereal"
+    ]
   },
   {
     "id": "CARD.TAG_TEAM",
@@ -1133,7 +1169,10 @@
     "cost": "3",
     "type": "Attack",
     "rarity": "Ancient",
-    "description": "Deal 33 damage. Stun the enemy. Exhaust."
+    "description": "Deal 33 damage. Stun the enemy. Exhaust.",
+    "keywords": [
+      "Exhaust"
+    ]
   },
   {
     "id": "CARD.WISH",
@@ -1142,7 +1181,11 @@
     "cost": "0",
     "type": "Skill",
     "rarity": "Ancient",
-    "description": "Put a card from your Draw Pile into your Hand. Exhaust."
+    "description": "Put a card from your Draw Pile into your Hand. Exhaust.",
+    "keywords": [
+      "Exhaust",
+      "Draw"
+    ]
   },
   {
     "id": "CARD.ASCENDERS_BANE",
@@ -3446,8 +3489,8 @@
     "cost": "2",
     "type": "Power",
     "rarity": "Rare",
-    "description": "Whenever you draw a card containing “Strike”, it is played against a random enemy.",
-    "description_upgraded": "Whenever you draw a card containing “Strike”, it is played against a random enemy.",
+    "description": "Whenever you draw a card containing \u201cStrike\u201d, it is played against a random enemy.",
+    "description_upgraded": "Whenever you draw a card containing \u201cStrike\u201d, it is played against a random enemy.",
     "keywords": [
       "Draw"
     ]
@@ -3659,8 +3702,8 @@
     "cost": "2",
     "type": "Attack",
     "rarity": "Common",
-    "description": "Deal 6 damage. Deals 2 additional damage for ALL your cards containing “Strike”.",
-    "description_upgraded": "Deal 6 damage. Deals 3 additional damage for ALL your cards containing “Strike”.",
+    "description": "Deal 6 damage. Deals 2 additional damage for ALL your cards containing \u201cStrike\u201d.",
+    "description_upgraded": "Deal 6 damage. Deals 3 additional damage for ALL your cards containing \u201cStrike\u201d.",
     "keywords": []
   },
   {

--- a/sts2/fetcher.py
+++ b/sts2/fetcher.py
@@ -808,11 +808,24 @@ def run_fetcher(save_only: bool = False):
                     filled = 0
                     for r in records:
                         sec = by_name.get(r["name"].lower())
-                        if sec and not r.get("description") and sec.get("description"):
+                        if not sec:
+                            continue
+                        if not r.get("description") and sec.get("description"):
                             r["description"] = sec["description"]
-                            if not r.get("description_upgraded") and sec.get("description_upgraded"):
-                                r["description_upgraded"] = sec["description_upgraded"]
+                            # Keywords are derived FROM the description, so a
+                            # record whose text arrives here keeps whatever it
+                            # had — usually nothing — and ships as a synergy
+                            # orphan invisible to the deck analyser.
+                            if "keywords" in r:
+                                r["keywords"] = _extract_keywords(r["description"])
                             filled += 1
+                        # Independent of the above: a record can have primary
+                        # text but no upgraded text. Nesting this inside the
+                        # description branch meant the secondary's upgraded
+                        # text was dropped whenever the primary supplied a
+                        # description.
+                        if not r.get("description_upgraded") and sec.get("description_upgraded"):
+                            r["description_upgraded"] = sec["description_upgraded"]
                     if filled:
                         print(f"    {source.name} filled text for {filled} {label}")
 

--- a/sts2/i18n.py
+++ b/sts2/i18n.py
@@ -8,7 +8,10 @@ To add a new language:
 2. Translate the values (not the keys)
 3. Set STS2_LANG=<code> environment variable
 
-No templates are wrapped yet — this is infrastructure for future contributors.
+The shared navigation chrome (base.html) and the settings page are wrapped;
+most page bodies are not, so contributions there are welcome. Entity text —
+card, relic, enemy and event names and descriptions — is translated
+separately, from the player's own game install, via `python -m sts2 localize`.
 """
 import json
 import logging

--- a/sts2/knowledge.py
+++ b/sts2/knowledge.py
@@ -222,6 +222,14 @@ class KnowledgeBase:
             except (json.JSONDecodeError, OSError) as exc:
                 log.warning("Skipping malformed mod file %s: %s", mod_file.name, exc)
                 continue
+            # Parsing is not validation: a file that is valid JSON but not an
+            # object (a bare list, a string) reached .get() and took the whole
+            # app down at import with an AttributeError, before any page could
+            # render. A hand-authored mod is exactly where that happens.
+            if not isinstance(data, dict):
+                log.warning("Skipping mod file %s: top level is %s, expected an object",
+                            mod_file.name, type(data).__name__)
+                continue
             mod_name = data.get("mod_name", mod_file.stem)
             # Namespace plumbing for installed-mod ingestion: a file that
             # declares mod_id gets its entities registered as
@@ -236,7 +244,24 @@ class KnowledgeBase:
                     record["id"] = f"mod:{mod_id}:{rid}"
                 return record
 
-            for d in data.get("cards", []):
+            def _records(key: str, _data=data, _name=mod_name) -> list:
+                """Entity list for `key`, or empty if the file got the shape wrong.
+
+                A string here would otherwise iterate character by character
+                and hand each one to _ns(), which then fails on .get().
+                """
+                value = _data.get(key, [])
+                if not isinstance(value, list):
+                    log.warning("Mod %s: %r is %s, expected a list",
+                                _name, key, type(value).__name__)
+                    return []
+                good = [r for r in value if isinstance(r, dict)]
+                if len(good) != len(value):
+                    log.warning("Mod %s: dropped %d non-object entries under %r",
+                                _name, len(value) - len(good), key)
+                return good
+
+            for d in _records("cards"):
                 d = _ns(d)
                 try:
                     card = Card(**d, source="mod")
@@ -247,7 +272,7 @@ class KnowledgeBase:
                     self.cards.append(card)
                 except Exception as exc:
                     log.warning("Mod %s: skipping malformed card: %s", mod_name, exc)
-            for d in data.get("relics", []):
+            for d in _records("relics"):
                 d = _ns(d)
                 try:
                     relic = Relic(**d, source="mod")
@@ -258,7 +283,7 @@ class KnowledgeBase:
                     self.relics.append(relic)
                 except Exception as exc:
                     log.warning("Mod %s: skipping malformed relic: %s", mod_name, exc)
-            for d in data.get("potions", []):
+            for d in _records("potions"):
                 d = _ns(d)
                 try:
                     potion = Potion(**d, source="mod")
@@ -268,7 +293,7 @@ class KnowledgeBase:
                     self.potions.append(potion)
                 except Exception as exc:
                     log.warning("Mod %s: skipping malformed potion: %s", mod_name, exc)
-            for d in data.get("enemies", []):
+            for d in _records("enemies"):
                 d = _ns(d)
                 try:
                     enemy = Enemy(**d, source="mod")

--- a/sts2/static/style.css
+++ b/sts2/static/style.css
@@ -20,10 +20,16 @@
   /* Dark gothic fantasy palette */
   --bg: #0c0a0e; --bg2: #151015; --bg3: #1e1620; --border: #3a2a1a;
   --text: #e8dcc8; --text2: #938880;
-  --gold: #c9a55c; --crimson: #d15858; --bronze: #a0784c; --copper: #a0784c;
+  /* --crimson and --bronze are used as text colours and measured 4.41:1 and
+     4.44:1 on --bg3, just under WCAG AA. Nudged lighter to clear 4.5:1 on all
+     three dark backgrounds. --copper keeps its value: it is only ever a
+     background or border, where the text ratio does not apply. */
+  --gold: #c9a55c; --crimson: #d95b5b; --bronze: #a67c4f; --copper: #a0784c;
   --accent: #c9a55c; --accent2: #8B1A1A;
-  --red: #d44d3f; --green: #4a9e5c; --yellow: #d4a857; --orange: #c97b2a;
-  --ironclad: #e74c3c; --silent: #2ecc71; --defect: #3498db; --necrobinder: #a563c0; --regent: #f1c40f;
+  /* --red and --necrobinder read 4.14:1 and 4.32:1 on --bg3 as text; nudged
+     lighter to clear WCAG AA on all three dark backgrounds. */
+  --red: #e75344; --green: #4a9e5c; --yellow: #d4a857; --orange: #c97b2a;
+  --ironclad: #e74c3c; --silent: #2ecc71; --defect: #3498db; --necrobinder: #ad67c9; --regent: #f1c40f;
   --card-bg: rgba(30,22,20,0.8);
   --nav-bg: rgba(18,14,16,0.92);
   --radius: 8px;
@@ -40,8 +46,12 @@
   --border: #d1c4b0; --text: #2a1f14; --text2: #6b5d4f;
   --gold: #7a5c1a; --crimson: #8b2020; --bronze: #6b5030; --copper: #6b5030;
   --accent: #7a5c1a; --accent2: #7a5c1a;
-  --red: #b91c1c; --green: #14753a; --yellow: #92700c; --orange: #a0580a;
-  --ironclad: #c0392b; --silent: #15753c; --defect: #2563eb; --necrobinder: #7e22ce; --regent: #7f6012;
+  /* --yellow darkened from #92700c: that measured 4.07:1 on --bg and only
+     3.66:1 on --bg3, below the 4.5:1 WCAG AA needs for body text. This clears
+     4.5:1 on all three light backgrounds while staying distinct from --gold
+     and --regent. */
+  --red: #b91c1c; --green: #14753a; --yellow: #7d5f00; --orange: #935009;
+  --ironclad: #b03427; --silent: #15753c; --defect: #225bd8; --necrobinder: #7e22ce; --regent: #7f6012;
   --card-bg: rgba(0,0,0,0.04);
   --nav-bg: rgba(250,246,239,0.92);
   --shadow-sm: 0 1px 3px rgba(0,0,0,0.1);

--- a/sts2/updater.py
+++ b/sts2/updater.py
@@ -149,6 +149,47 @@ def get_data_update_info() -> dict | None:
     return _data_update
 
 
+def _merge_local_build_ids(local_patches, staged_patches) -> None:
+    """Carry hand-assigned build_id -> patch mappings across a bundle install.
+
+    The bundle ships patches.json, and the staging rule is "bundle wins for its
+    own files", so /admin/patches assignments were discarded on every data
+    update — silently changing which runs count as current-patch and therefore
+    the win rates shown. Build ids are user knowledge the bundle cannot know,
+    so they are unioned back in; everything else still comes from the bundle.
+    """
+    if not local_patches.exists() or not staged_patches.exists():
+        return
+    try:
+        local = json.loads(local_patches.read_text(encoding="utf-8"))
+        staged = json.loads(staged_patches.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Could not merge local patch assignments: %s", exc)
+        return
+    if not isinstance(local, list) or not isinstance(staged, list):
+        return
+    local_ids = {p.get("patch"): p.get("build_ids") or []
+                 for p in local if isinstance(p, dict)}
+    carried = 0
+    for entry in staged:
+        if not isinstance(entry, dict):
+            continue
+        mine = [b for b in local_ids.get(entry.get("patch"), []) if isinstance(b, str)]
+        if not mine:
+            continue
+        existing = entry.setdefault("build_ids", [])
+        for build_id in mine:
+            if build_id not in existing:
+                existing.append(build_id)
+                carried += 1
+    if carried:
+        try:
+            staged_patches.write_text(json.dumps(staged, indent=2) + "\n", encoding="utf-8")
+            log.info("Carried %d local build-id assignment(s) into the new patch manifest", carried)
+        except OSError as exc:
+            log.warning("Could not write merged patch manifest: %s", exc)
+
+
 def install_data_update() -> tuple[bool, str]:
     """Download, sha256-verify, and atomically install the pending bundle.
 
@@ -206,6 +247,7 @@ def install_data_update() -> tuple[bool, str]:
                     shutil.copytree(item, target)
                 else:
                     shutil.copy2(item, target)
+            _merge_local_build_ids(DATA_DIR / "patches.json", staging / "patches.json")
             DATA_DIR.rename(backup)
             try:
                 staging.rename(DATA_DIR)

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -537,3 +537,34 @@ def test_enemy_hp_uses_one_field_name():
     assert not stray, f"entries use 'hp' instead of 'hp_range': {stray}"
     missing_field = [e.get("id") for e in entries if "hp_range" not in e]
     assert not missing_field, f"entries have no hp_range field at all: {missing_field}"
+
+
+def test_gap_filled_description_re_derives_keywords(tmp_path, monkeypatch):
+    """Keywords are derived from the description, so text arriving via gap-fill
+    must re-derive them or the card ships as a synergy orphan the deck
+    analyser cannot see."""
+    cards = _run_orchestrator(
+        tmp_path, monkeypatch,
+        primary_result=[_card("Blank", description="", keywords=[])],
+        secondary_result=[_card("Blank", description="Gain 5 Block. Exhaust.")],
+    )
+    blank = next(c for c in cards if c["name"] == "Blank")
+    assert blank["description"] == "Gain 5 Block. Exhaust."
+    assert set(blank["keywords"]) == {"Block", "Exhaust"}
+
+
+def test_gap_fill_adopts_upgraded_text_even_when_primary_had_a_description(
+        tmp_path, monkeypatch):
+    """The upgraded-text fill used to be nested inside the "no description"
+    branch, so a card whose primary text existed never picked up the
+    secondary's upgraded text."""
+    cards = _run_orchestrator(
+        tmp_path, monkeypatch,
+        primary_result=[_card("Both", description="Deal 6 damage.",
+                              description_upgraded="")],
+        secondary_result=[_card("Both", description="Deal 6 damage.",
+                                description_upgraded="Deal 9 damage.")],
+    )
+    both = next(c for c in cards if c["name"] == "Both")
+    assert both["description"] == "Deal 6 damage."
+    assert both["description_upgraded"] == "Deal 9 damage."

--- a/tests/test_enchantments.py
+++ b/tests/test_enchantments.py
@@ -101,15 +101,29 @@ def test_discover_badges_from_saves(tmp_path):
                       "requirement": "", "source": "discovered"}]
 
 
-def test_deprecated_epochs_never_suggested():
-    from sts2.models import Epoch
-    active = Epoch(id="EPOCH.A", name="A")
-    dead = Epoch(id="EPOCH.B", name="B", status="deprecated")
-    # mirror the routes.py suggestion predicate
-    obtained = set()
-    suggestable = [e for e in (active, dead)
-                   if e.id not in obtained and e.status != "deprecated"]
-    assert suggestable == [active]
+async def test_deprecated_epochs_never_suggested(client):
+    """Drive the real home-page route rather than a copy of its predicate.
+
+    The previous version rebuilt the filter inline and asserted against its own
+    list comprehension, so deleting the guard in routes.py left it green while
+    the home page started recommending epochs that can no longer be earned.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from sts2.models import Epoch, PlayerProgress
+
+    active = Epoch(id="EPOCH.ACTIVE", name="Still Earnable", requirement="Win a run")
+    dead = Epoch(id="EPOCH.DEAD", name="Retired Epoch", requirement="Cannot be earned",
+                 status="deprecated")
+    progress = PlayerProgress(epochs=[{"id": "EPOCH.OTHER", "state": "revealed"}])
+
+    from sts2.app import kb as _kb
+    with patch.object(_kb, "epochs", [dead, active]), \
+         patch("sts2.app._get_progress", new=AsyncMock(return_value=progress)):
+        html = (await client.get("/")).text
+
+    assert "Still Earnable" in html, "an earnable epoch should be suggested"
+    assert "Retired Epoch" not in html, "a deprecated epoch must never be suggested"
 
 
 # ── P10: i18n language persistence + fallback ──

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -230,3 +230,51 @@ def test_changelog_has_no_bare_at_mentions():
         "bare @mentions in CHANGELOG.md would be auto-linked in the generated "
         f"release notes and notify those accounts: {sorted(set(mentions))}. "
         "Wrap them in backticks.")
+
+
+@pytest.mark.parametrize("theme", ["dark", "light"])
+def test_theme_text_colours_meet_wcag_aa(theme):
+    """Every variable used as a text colour, on every background of its theme.
+
+    The browser suite's check listed 8 of 17 colours by hand and omitted
+    --yellow, which shipped at 4.07:1 on --bg and 3.66:1 on --bg3. Enumerating
+    from the stylesheet covers a newly added colour without anyone remembering
+    to extend a list.
+
+    Only variables that actually appear in a `color:` declaration are checked —
+    AA's 4.5:1 applies to text. --accent2, for instance, measures 1.90:1 but is
+    only ever a background, so holding it to a text ratio would be wrong.
+    """
+    import re
+
+    css = (PROJECT_ROOT / "sts2" / "static" / "style.css").read_text(encoding="utf-8")
+    selector = r":root" if theme == "dark" else r'\[data-theme="light"\]'
+    block = re.search(selector + r"\s*\{(.*?)\}", css, re.S)
+    assert block, f"{theme} theme block not found"
+    colours = dict(re.findall(r"--([\w-]+):\s*(#[0-9a-fA-F]{6})", block.group(1)))
+    backgrounds = {k: v for k, v in colours.items() if k in ("bg", "bg2", "bg3")}
+    assert len(backgrounds) == 3, f"expected three {theme} backgrounds, got {backgrounds}"
+
+    used_as_text = set(re.findall(r"(?<!-)\bcolor:\s*var\(--([\w-]+)\)", css))
+    assert used_as_text, "no text colours found — the usage scan is broken"
+
+    def luminance(value):
+        parts = [int(value[i:i + 2], 16) / 255 for i in (1, 3, 5)]
+        chan = [c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4 for c in parts]
+        return 0.2126 * chan[0] + 0.7152 * chan[1] + 0.0722 * chan[2]
+
+    def ratio(fg, bg):
+        a, b = luminance(fg), luminance(bg)
+        hi, lo = max(a, b), min(a, b)
+        return (hi + 0.05) / (lo + 0.05)
+
+    failures = []
+    for name, fg in colours.items():
+        if name not in used_as_text or name in backgrounds:
+            continue
+        for bg_name, bg in backgrounds.items():
+            r = ratio(fg, bg)
+            if r < 4.5:
+                failures.append(f"--{name} {fg} on --{bg_name} {bg} = {r:.2f}:1")
+    assert not failures, (
+        f"{theme} theme text below WCAG AA (4.5:1):\n  " + "\n  ".join(failures))

--- a/tests/test_v2_features.py
+++ b/tests/test_v2_features.py
@@ -618,10 +618,17 @@ class TestTheme:
         from sts2.config import STATIC_DIR
         css = (STATIC_DIR / "style.css").read_text(encoding="utf-8")
         assert '[data-theme="light"]' in css
-        # Check critical overrides
-        assert "--regent: #7f6012" in css  # WCAG-safe regent color
-        assert "--silent: #15753c" in css   # WCAG-safe silent color
-        assert "--ironclad: #c0392b" in css # WCAG-safe ironclad color
+        # The light theme must override the character and status colours, but
+        # pin the names rather than the hex values: the old version hardcoded
+        # three literals and annotated them "WCAG-safe" when --ironclad
+        # #c0392b actually measured 4.30:1 on --bg3. Contrast is verified for
+        # real, across every colour and background, in
+        # test_theme_text_colours_meet_wcag_aa.
+        import re
+        block = re.search(r'\[data-theme="light"\]\s*\{([^}]+)\}', css)
+        assert block, "no light theme block"
+        for name in ("--regent", "--silent", "--ironclad", "--yellow", "--red"):
+            assert f"{name}:" in block.group(1), f"light theme does not override {name}"
 
     def test_css_card_bg_not_circular(self):
         from sts2.config import STATIC_DIR
@@ -944,21 +951,25 @@ class TestWCAGContrast:
 
     LIGHT_BG = "#f5f0e8"
     # All text/accent colors from [data-theme="light"] CSS block
-    WCAG_AA_PAIRS = [
-        ("--text", "#2a1f14"),
-        ("--text2", "#6b5d4f"),
-        ("--gold", "#7a5c1a"),
-        ("--ironclad", "#c0392b"),
-        ("--silent", "#15753c"),
-        ("--regent", "#7f6012"),
-        ("--red", "#b91c1c"),
-        ("--green", "#14753a"),
-    ]
+    # Read from the stylesheet rather than restated here. The hardcoded
+    # version listed 8 of 17 colours and omitted --yellow, which shipped at
+    # 4.07:1 — the list itself was the blind spot.
+    @staticmethod
+    def _light_colours() -> list[tuple[str, str]]:
+        import re
+
+        from sts2.config import STATIC_DIR
+        css = (STATIC_DIR / "style.css").read_text(encoding="utf-8")
+        block = re.search(r'\[data-theme="light"\]\s*\{([^}]+)\}', css)
+        assert block, "no light theme block"
+        found = re.findall(r"--([\w-]+):\s*(#[0-9a-fA-F]{6})", block.group(1))
+        skip = {"bg", "bg2", "bg3", "border", "card-bg", "nav-bg", "accent2"}
+        return [(f"--{n}", v) for n, v in found if n not in skip]
 
     def test_all_text_colors_pass_wcag_aa(self):
         """All light-theme text/accent colors must have >= 4.5:1 contrast on bg."""
         failures = []
-        for name, color in self.WCAG_AA_PAIRS:
+        for name, color in self._light_colours():
             ratio = _contrast_ratio(color, self.LIGHT_BG)
             if ratio < 4.5:
                 failures.append(f"{name} ({color}): {ratio:.2f}:1 < 4.5:1")
@@ -979,7 +990,7 @@ class TestWCAGContrast:
         match = re.search(r'\[data-theme="light"\]\s*\{([^}]+)\}', css)
         assert match, "No [data-theme='light'] block in CSS"
         block = match.group(1)
-        for name, expected_color in self.WCAG_AA_PAIRS:
+        for name, expected_color in self._light_colours():
             assert expected_color in block, f"{name}: {expected_color} not found in light theme CSS"
 
 


### PR DESCRIPTION
Working through the audit backlog. Every item reproduced before the fix, and each new test confirmed failing without it.

## Crashes and data loss

- **A malformed mod took the whole app down at import.** A file that is valid JSON but not an object — a bare list, a string, or a `cards` value that is not a list of objects — hit `.get()` and raised before any page could render. Malformed mods now degrade with a warning; a valid mod still loads.
- **Data-bundle installs discarded hand-assigned `build_id → patch` mappings.** The bundle ships `patches.json` and the staging rule is "bundle wins for its own files", so every data update silently reset which runs count as current-patch — and therefore the win rates shown.

## Accessibility

The light theme shipped `--yellow` at **4.07:1** on `--bg` and **3.66:1** on `--bg3`. Enumerating every colour instead of the hand-listed eight found **three more** below AA (`--orange`, `--ironclad`, `--defect`), and the dark theme had four (`--red`, `--necrobinder`, `--crimson`, `--bronze`).

The check now reads colours from the stylesheet and holds only variables used in a `color:` declaration to the text ratio — `--accent2` measures 1.90:1 but is only ever a background, so treating it as text would be wrong. The two older tests that hardcoded hexes and annotated `--ironclad #c0392b` as "WCAG-safe" (it was 4.30:1) now derive their values from the CSS.

## Data quality

13 cards shipped with a description and no keywords, invisible to synergy analysis. The cause is in the fetcher: field-level gap-fill adopts a secondary source's description **without re-deriving keywords from it**. Fixed at the source and in the data — the extractor agrees exactly with all 419 cards that already carry keywords, and the remaining 191 descriptions genuinely contain none.

The same gap-fill nested its upgraded-text fill inside the "no description" branch, so a card whose primary text existed never picked up the secondary's upgraded text.

## Release safety

Both release workflows now verify the tag matches `VERSION` before building. Four releases (v2.9.4–v2.9.7) shipped binaries whose reported version did not match their tag.

## Test quality

`test_deprecated_epochs_never_suggested` rebuilt the route's predicate inline and asserted against its own copy, so deleting the real guard left it green. It now drives the home page — confirmed it fails when the guard is removed.

- [x] `pytest -q` passes (780)
- [x] `ruff check` passes
- [x] Rebuilt the frozen artifact and drove 20 pages: 3.0.5, playtime `53h 40m`, Aeonglass HP 512, zero raw i18n keys