### PR TITLE
Open the browser automatically from packaged builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A local-first intelligence dashboard for **Slay the Spire 2** — card/relic/ene
 
 ### Download (No Python Required)
 
-**[Download Spirescope for Windows](https://github.com/thequantumfalcon/spirescope/releases/latest/download/Spirescope-windows.zip)** — extract the zip, open the `Spirescope` folder, double-click `Spirescope.exe`, leave the console window open, then open `http://127.0.0.1:8000` in your browser. A macOS build ([Spirescope-macos.zip](https://github.com/thequantumfalcon/spirescope/releases/latest/download/Spirescope-macos.zip)) is also attached to each release. All archives ship with `.sha256` checksum files.
+**[Download Spirescope for Windows](https://github.com/thequantumfalcon/spirescope/releases/latest/download/Spirescope-windows.zip)** — extract the zip, open the `Spirescope` folder and double-click `Spirescope.exe`. Your browser opens automatically; leave the console window open while you use it, since closing it stops the app. (If the browser doesn't open, go to `http://127.0.0.1:8000` yourself.) A macOS build ([Spirescope-macos.zip](https://github.com/thequantumfalcon/spirescope/releases/latest/download/Spirescope-macos.zip)) is also attached to each release. All archives ship with `.sha256` checksum files.
 
 > **Windows may warn you, or block the file outright** ("contains a virus or
 > potentially unwanted software"). This is a false positive on unsigned
@@ -269,7 +269,7 @@ spirescope --version    # Show version
 | `STS2_SYNC_KEY` | API key for sync service | None |
 | `SPIRESCOPE_API_KEY` | Optional API key for rate limit bypass | None |
 | `SPIRESCOPE_ADMIN_TOKEN` | Token for `/api/reload` and `/api/reset/stats` | Auto-generated |
-| `SPIRESCOPE_OPEN_BROWSER` | `1`/`0` override for browser auto-open on `serve` | Source: enabled, frozen build: disabled |
+| `SPIRESCOPE_OPEN_BROWSER` | `1`/`0` override for browser auto-open on `serve` | Enabled |
 | `SPIRESCOPE_CHECK_UPDATES` | `1`/`0` override for automatic GitHub update checks | Source: enabled, frozen build: disabled |
 | `STS2_CORS_ORIGINS` | Comma-separated CORS allowed origins | Localhost only |
 

--- a/README_DIST.txt
+++ b/README_DIST.txt
@@ -23,8 +23,10 @@ IF WINDOWS BLOCKED THIS FILE:
 HOW TO RUN:
 
   1. Double-click Spirescope.exe
-  2. Leave the console window open while Spirescope is running
-  3. Open http://127.0.0.1:8000 in your browser
+  2. Your browser opens automatically
+  3. Leave the console window open while Spirescope is running -
+     closing it stops the app
+     (If the browser does not open, go to http://127.0.0.1:8000 yourself)
 
 --------------------------------------------------------------------------
 macOS
@@ -49,8 +51,10 @@ HOW TO RUN:
 
   1. Open Terminal in this folder
   2. Run:  ./Spirescope
-  3. Leave the terminal window open while Spirescope is running
-  4. Open http://127.0.0.1:8000 in your browser
+  3. Your browser opens automatically
+  4. Leave the terminal window open while Spirescope is running -
+     closing it stops the app
+     (If the browser does not open, go to http://127.0.0.1:8000 yourself)
 
 --------------------------------------------------------------------------
 BOTH PLATFORMS
@@ -58,8 +62,8 @@ BOTH PLATFORMS
 
 OPTIONAL:
 
-  - To auto-open the browser, launch with --browser
-  - Or set SPIRESCOPE_OPEN_BROWSER=1 before launching
+  - To stop the browser opening automatically, launch with --no-browser
+    or set SPIRESCOPE_OPEN_BROWSER=0
 
 FEATURES:
 

--- a/sts2/__main__.py
+++ b/sts2/__main__.py
@@ -86,7 +86,15 @@ def _should_open_browser(args: list[str]) -> bool:
     if env_override is not None:
         return env_override
 
-    return not getattr(sys, "frozen", False)
+    # Open the browser by default everywhere, packaged builds included.
+    # Frozen builds used to be excluded, which inverted the default relative to
+    # who runs them: the packaged exe is what a player double-clicks, and it
+    # greeted them with a console window telling them to go type a URL, while
+    # the source run — used by developers, who need it least — opened it.
+    # The antivirus mitigation documented in docs/ANTIVIRUS.md is the *visible
+    # console* (avoiding the hidden-window profile), which is unchanged here.
+    # `--no-browser` and SPIRESCOPE_OPEN_BROWSER=0 still opt out.
+    return True
 
 
 def main():
@@ -210,9 +218,17 @@ def main():
             threading.Timer(1.5, lambda: webbrowser.open(url)).start()
         # flush so the banner reaches redirected/supervised logs immediately
         print(f"\n  Spirescope {_get_version()} starting at {url}", flush=True)
-        if getattr(sys, "frozen", False) and not open_browser:
-            print("  Browser auto-open is disabled for the packaged build by default.")
-            print("  Open the URL above manually, or launch with '--browser'.", flush=True)
+        if open_browser:
+            # The console stays open on purpose (see docs/ANTIVIRUS.md), so say
+            # why — a black window with a log line in it reads like something
+            # went wrong to anyone who just double-clicked the icon.
+            print("  Opening your browser now. If nothing happens, open the URL above.")
+            print("  Keep this window open while you use Spirescope; closing it stops the app.",
+                  flush=True)
+        else:
+            print("  Browser auto-open is turned off. Open the URL above manually.")
+            print("  Keep this window open while you use Spirescope; closing it stops the app.",
+                  flush=True)
         if HOST not in ("127.0.0.1", "localhost", "::1"):
             print("  WARNING: Spirescope is designed for single-user local use.")
             print("  Binding to a public address exposes it without authentication.\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,9 +189,25 @@ def test_should_open_browser_default_source():
 
 
 def test_should_open_browser_default_frozen():
+    """A packaged build must open the browser too.
+
+    The default used to be "source yes, frozen no", which is inverted relative
+    to who runs each: the exe is what a player double-clicks, and it left them
+    staring at a console telling them to type a URL. The antivirus mitigation
+    is the visible console, not this.
+    """
     with patch.object(sys, "frozen", True, create=True), \
          patch.dict("os.environ", {}, clear=False):
-        assert _should_open_browser([]) is False
+        assert _should_open_browser([]) is True
+
+
+def test_should_open_browser_frozen_respects_opt_outs():
+    """Flipping the default must not remove the ways to turn it off."""
+    with patch.object(sys, "frozen", True, create=True):
+        with patch.dict("os.environ", {}, clear=False):
+            assert _should_open_browser(["--no-browser"]) is False
+        with patch.dict("os.environ", {"SPIRESCOPE_OPEN_BROWSER": "0"}, clear=False):
+            assert _should_open_browser([]) is False
 
 
 def test_should_open_browser_env_override():


### PR DESCRIPTION
Reported by a player who double-clicked `Spirescope.exe` and got a console window telling her to go type a URL.

## The inversion

The default was *"open the browser unless this is a frozen build"* — backwards relative to who runs each one. The packaged exe is what a player double-clicks; running from source is what a developer does. The person who least needs it got the browser opened; the person who most needs it got a black window that reads like a failure.

## What changed

Packaged builds now open the browser. `--no-browser` and `SPIRESCOPE_OPEN_BROWSER=0` still opt out.

**The visible console is unchanged.** That is the antivirus mitigation `docs/ANTIVIRUS.md` actually relies on — avoiding the hidden-window profile — not the browser call. I checked the commit and changelog that introduced this before touching it. The console now also explains itself, since "closing this stops the app" is not obvious to someone who just double-clicked an icon.

Before:
```
Spirescope 3.0.4 starting at http://127.0.0.1:8000
Browser auto-open is disabled for the packaged build by default.
Open the URL above manually, or launch with '--browser'.
```

After:
```
Spirescope 3.0.5 starting at http://127.0.0.1:8000
Opening your browser now. If nothing happens, open the URL above.
Keep this window open while you use Spirescope; closing it stops the app.
```

README, the env-var table, and the `README_DIST.txt` that ships inside both zips all told users to open the URL by hand; all three now describe what actually happens.

- [x] `pytest -q` passes (781)
- [x] `ruff check` passes
- [x] Tests pin the new default *and* that both opt-outs still work
- [x] Verified on the rebuilt packaged artifact, which is where the report came from