### PR TITLE
Give packaged users commands they can actually run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@
   outside code formatting, so it was auto-linked to a real user with no
   connection to this project. The published notes are corrected and the
   changelog can no longer reintroduce it.
+- **The app no longer tells you to run commands you do not have.** Every
+  command shown in the interface was written for a source checkout, so a
+  player who downloaded the executable was told to run `python -m sts2
+  community` — with no Python installed and no `spirescope` on PATH. The
+  Community, home, Settings and Guide pages now show `Spirescope.exe
+  community` (and so on) in packaged builds, and `--help` reports the
+  executable it was actually launched as.
+- **The guide described the old browser behaviour.** It contrasted source
+  installs opening a browser against the packaged build only keeping a console
+  window open, which stopped being true once packaged builds began opening the
+  browser too.
 
 ### Internal
 

--- a/sts2/__main__.py
+++ b/sts2/__main__.py
@@ -39,7 +39,7 @@ Commands:
   sync-down     Download and merge community stats from sync service
 
 Options:
-    --browser     With 'serve': force opening browser automatically
+  --browser     With 'serve': force opening browser automatically
   --save-only   With 'update': skip wiki, only discover from save files
   --no-browser  With 'serve': don't open browser automatically
   --lang CODES  With 'localize': comma-separated languages (default: all)
@@ -48,7 +48,7 @@ Options:
   --version, -V Show version
 
 Environment:
-    SPIRESCOPE_OPEN_BROWSER  1/0 override for auto-opening browser on 'serve'
+  SPIRESCOPE_OPEN_BROWSER  1/0 override for auto-opening browser on 'serve'
   STS2_SYNC_URL   Sync service URL (required for sync-up/sync-down)
   STS2_SYNC_KEY   Optional API key for sync service authentication
 """

--- a/sts2/__main__.py
+++ b/sts2/__main__.py
@@ -11,10 +11,22 @@ if sys.stdout is None:
 if sys.stderr is None:
     sys.stderr = open(os.devnull, "w")
 
+def _program_name() -> str:
+    """How the reader invoked this, so the help text matches their situation.
+
+    A packaged build has no `spirescope` entry point on PATH and no Python;
+    printing "Usage: spirescope" tells that reader to run something they do
+    not have.
+    """
+    if getattr(sys, "frozen", False):
+        return os.path.basename(sys.executable)
+    return "spirescope"
+
+
 USAGE = """\
 Spirescope - Slay the Spire 2 companion dashboard
 
-Usage: spirescope [command] [options]
+Usage: {prog} [command] [options]
 
 Commands:
   serve         Start the web dashboard (default)
@@ -101,7 +113,7 @@ def main():
     args = sys.argv[1:]
 
     if "--help" in args or "-h" in args:
-        print(USAGE)
+        print(USAGE.format(prog=_program_name()))
         return
 
     if "--version" in args or "-V" in args:
@@ -239,7 +251,7 @@ def main():
         return
 
     print(f"Unknown command: {command}\n")
-    print(USAGE)
+    print(USAGE.format(prog=_program_name()))
     sys.exit(1)
 
 if __name__ == "__main__":

--- a/sts2/app.py
+++ b/sts2/app.py
@@ -9,6 +9,7 @@ import os
 import re
 import secrets
 import struct
+import sys
 import time
 
 from fastapi import FastAPI, Request
@@ -74,6 +75,13 @@ templates.env.globals["theme_init_hash"] = _THEME_INIT_HASH
 templates.env.globals["logo_hash"] = _LOGO_HASH
 templates.env.globals["hero_bg_hash"] = _HERO_BG_HASH
 templates.env.globals["version"] = VERSION
+# How to invoke the CLI, phrased for whoever is actually reading the page.
+# Packaged builds have neither Python nor a `spirescope` entry point on PATH,
+# so telling that reader to run `python -m sts2 update` is an instruction they
+# cannot follow — they have the executable they double-clicked and nothing else.
+templates.env.globals["is_frozen"] = getattr(sys, "frozen", False)
+templates.env.globals["cli"] = (
+    "Spirescope.exe" if getattr(sys, "frozen", False) else "spirescope")
 from sts2 import patches as _patches  # noqa: E402
 from sts2.i18n import get_language, get_translator  # noqa: E402
 

--- a/sts2/app.py
+++ b/sts2/app.py
@@ -79,9 +79,12 @@ templates.env.globals["version"] = VERSION
 # Packaged builds have neither Python nor a `spirescope` entry point on PATH,
 # so telling that reader to run `python -m sts2 update` is an instruction they
 # cannot follow — they have the executable they double-clicked and nothing else.
+# Taken from the running executable rather than hardcoded, because the macOS
+# build is named `Spirescope` with no extension.
+from sts2.__main__ import _program_name  # noqa: E402
+
 templates.env.globals["is_frozen"] = getattr(sys, "frozen", False)
-templates.env.globals["cli"] = (
-    "Spirescope.exe" if getattr(sys, "frozen", False) else "spirescope")
+templates.env.globals["cli"] = _program_name()
 from sts2 import patches as _patches  # noqa: E402
 from sts2.i18n import get_language, get_translator  # noqa: E402
 

--- a/sts2/templates/community.html
+++ b/sts2/templates/community.html
@@ -90,7 +90,7 @@
 
 {% if not meta_posts and not tier_cards and (not aggregate or not aggregate.run_count or aggregate.run_count < 10) %}
 <div class="text-muted mt-lg mb-lg">
-  <p>Nothing here yet — run <code>python -m sts2 community</code> to pull in the latest tier lists and strategy guides from the Steam community.</p>
+  <p>Nothing here yet — run <code>{{ cli }} community</code> to pull in the latest tier lists and strategy guides from the Steam community.</p>
 </div>
 {% endif %}
 {% endblock %}

--- a/sts2/templates/guide.html
+++ b/sts2/templates/guide.html
@@ -26,10 +26,20 @@
 
 <h2 id="getting-started">Getting Started</h2>
 <div class="card mb-md">
+{% if is_frozen %}
+  <p>You are already running it. Double-click <code>Spirescope.exe</code> any time
+  to start the dashboard — it opens your browser at
+  <code>http://127.0.0.1:8000</code> and keeps a console window open while it
+  serves. Closing that window stops the app.</p>
+  <p class="text-sm text-muted mt-sm">The commands below are run the same way:
+  open the folder containing <code>Spirescope.exe</code>, then run
+  <code>Spirescope.exe update</code> (and so on) from a terminal there.</p>
+{% else %}
   <p>Install SpireScope and start the dashboard:</p>
   <pre><code>pip install -e .
 spirescope</code></pre>
-  <p class="text-sm text-muted mt-sm">Or run directly with <code>python -m sts2</code>. Source installs open your browser automatically at <code>http://127.0.0.1:8000</code>. The packaged Windows build keeps a console window open and serves the same local address by default.</p>
+  <p class="text-sm text-muted mt-sm">Or run directly with <code>python -m sts2</code>. It opens your browser automatically at <code>http://127.0.0.1:8000</code>; the packaged build does the same and additionally keeps a console window open, which stops the app when closed.</p>
+{% endif %}
 </div>
 
 <h2 id="save-files">Save File Setup</h2>
@@ -46,9 +56,9 @@ export STS2_SAVE_DIR=~/.local/share/SlayTheSpire2/steam/YOUR_ID/profile1/saves</
 <h2 id="updating-data">Updating Data</h2>
 <div class="card mb-md">
   <p>SpireScope ships with baked-in game data. To fetch the latest cards, relics, and potions from the wiki:</p>
-  <pre><code>spirescope update</code></pre>
+  <pre><code>{{ cli }} update</code></pre>
   <p class="mt-sm">If you don't have internet access or just want to discover new entities from your save files:</p>
-  <pre><code>spirescope update --save-only</code></pre>
+  <pre><code>{{ cli }} update --save-only</code></pre>
   <p class="text-sm text-muted mt-sm">You can also hot-reload data without restarting by calling <code>POST /api/reload</code> with header <code>X-Admin-Token: YOUR_TOKEN</code>. Set <code>SPIRESCOPE_ADMIN_TOKEN</code> env var or enable debug logging to see the auto-generated token.</p>
 </div>
 
@@ -106,7 +116,7 @@ export STS2_SAVE_DIR=~/.local/share/SlayTheSpire2/steam/YOUR_ID/profile1/saves</
 <h2 id="community">Community Data</h2>
 <div class="card mb-md">
   <p>Fetch community tips and meta posts from the Steam community:</p>
-  <pre><code>spirescope community</code></pre>
+  <pre><code>{{ cli }} community</code></pre>
   <p class="text-sm text-muted mt-sm">Community tips appear on card, relic, and enemy detail pages. Meta posts appear on the Community page.</p>
 </div>
 
@@ -233,7 +243,7 @@ export STS2_SAVE_DIR=~/.local/share/SlayTheSpire2/steam/YOUR_ID/profile1/saves</
 <h2 id="troubleshooting">Troubleshooting</h2>
 <div class="card mb-md">
   <p><strong>"No save files found"</strong> &mdash; Set <code>STS2_SAVE_DIR</code> to point to your saves directory. Make sure you've launched STS2 at least once.</p>
-  <p class="mt-sm"><strong>Empty card/relic lists</strong> &mdash; Run <code>spirescope update</code> to fetch data from the wiki.</p>
+  <p class="mt-sm"><strong>Empty card/relic lists</strong> &mdash; Run <code>{{ cli }} update</code> to fetch data from the wiki.</p>
   <p class="mt-sm"><strong>Live run not updating</strong> &mdash; The game must be running with an active run. Check that your save directory is correct.</p>
   <p class="mt-sm"><strong>Port already in use</strong> &mdash; Set <code>STS2_PORT=8001</code> (or any free port) before starting.</p>
   <p class="mt-sm"><strong>Rate limited (429)</strong> &mdash; The server limits to 60 requests per minute per IP. Wait a moment and try again.</p>

--- a/sts2/templates/index.html
+++ b/sts2/templates/index.html
@@ -110,7 +110,7 @@
   </p>
   {% if data_age_days is not none and data_age_days > 30 %}
   <p class="text-sm text-yellow mt-sm">
-    Wiki data is <strong>{{ data_age_days }} days old</strong>. Run <code>python -m sts2 update</code> to refresh card/relic/potion data.
+    Wiki data is <strong>{{ data_age_days }} days old</strong>. Run <code>{{ cli }} update</code> to refresh card/relic/potion data.
   </p>
   {% endif %}
 </div>

--- a/sts2/templates/settings.html
+++ b/sts2/templates/settings.html
@@ -21,6 +21,6 @@
 {% elif content_translated %}
 <p class="text-sm text-muted mt-md">Card, relic and enemy text is translated. Entries the game does not translate stay in English.</p>
 {% else %}
-<p class="text-sm text-muted mt-md">Only the interface is translated. To translate card, relic and enemy text as well, run <code>spirescope localize</code> once — it builds the text from the Slay the Spire 2 files already on your machine.</p>
+<p class="text-sm text-muted mt-md">Only the interface is translated. To translate card, relic and enemy text as well, run <code>{{ cli }} localize</code> once — it builds the text from the Slay the Spire 2 files already on your machine.</p>
 {% endif %}
 {% endblock %}

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -5,6 +5,7 @@ added to the PyInstaller spec, so every packaged v3.0.0/v3.0.1 build
 rendered raw translation keys ("nav.cards") in the navigation. Source runs
 were fine, which is exactly why source-only testing missed it.
 """
+import re
 from pathlib import Path
 
 import pytest
@@ -278,3 +279,54 @@ def test_theme_text_colours_meet_wcag_aa(theme):
                 failures.append(f"--{name} {fg} on --{bg_name} {bg} = {r:.2f}:1")
     assert not failures, (
         f"{theme} theme text below WCAG AA (4.5:1):\n  " + "\n  ".join(failures))
+
+
+# ── CLI instructions must match how the reader actually runs the app ──
+
+def test_ui_never_hardcodes_a_source_only_command():
+    """A packaged reader has no Python and no `spirescope` on PATH.
+
+    Telling them to run `python -m sts2 community` is an instruction they
+    cannot follow: they have the executable they double-clicked. Commands
+    shown in the UI go through the `cli` global instead, so they read
+    correctly for whoever is looking at the page. The guide is exempt only
+    inside its explicit source-install branch, which is guarded separately.
+    """
+    source_only = re.compile(r"<code>(?:python -m sts2|spirescope)\s+\w")
+    offenders = []
+    for path in sorted((PKG / "templates").glob("*.html")):
+        text = path.read_text(encoding="utf-8")
+        if path.name == "guide.html":
+            continue
+        for line in text.splitlines():
+            if source_only.search(line):
+                offenders.append(f"{path.name}: {line.strip()[:90]}")
+    assert not offenders, (
+        "UI shows a command a packaged user cannot run:\n  " + "\n  ".join(offenders))
+
+
+def test_guide_offers_both_invocations():
+    """The guide keeps source instructions, but only behind is_frozen."""
+    text = (PKG / "templates" / "guide.html").read_text(encoding="utf-8")
+    assert "{% if is_frozen %}" in text, "guide no longer branches on build type"
+    assert "{{ cli }} update" in text, "guide hardcodes the update command"
+    assert "{{ cli }} community" in text, "guide hardcodes the community command"
+    # the pip/source lines must sit in the else branch, not the frozen one
+    frozen_branch = text.split("{% if is_frozen %}")[1].split("{% else %}")[0]
+    assert "pip install" not in frozen_branch
+    assert "python -m sts2" not in frozen_branch
+
+
+def test_cli_global_matches_the_running_form(monkeypatch):
+    """The `cli` template global names the executable in frozen builds."""
+    import importlib
+    import sys as _sys
+
+    monkeypatch.setattr(_sys, "frozen", True, raising=False)
+    monkeypatch.setattr(_sys, "executable", r"C:\x\Spirescope.exe", raising=False)
+    from sts2 import __main__ as entry
+    importlib.reload(entry)
+    assert entry._program_name() == "Spirescope.exe"
+    monkeypatch.delattr(_sys, "frozen", raising=False)
+    importlib.reload(entry)
+    assert entry._program_name() == "spirescope"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -317,16 +317,23 @@ def test_guide_offers_both_invocations():
     assert "python -m sts2" not in frozen_branch
 
 
-def test_cli_global_matches_the_running_form(monkeypatch):
-    """The `cli` template global names the executable in frozen builds."""
-    import importlib
+@pytest.mark.parametrize("exe_name", ["Spirescope.exe", "Spirescope"])
+def test_cli_names_the_running_executable(monkeypatch, exe_name):
+    """Frozen builds report their own binary, whatever it is called.
+
+    The name is read from sys.executable rather than hardcoded: the Windows
+    build is Spirescope.exe and the macOS build is Spirescope, so a literal
+    would be wrong on one of them. The path is built with os.path.join so the
+    test means the same thing on a Linux CI runner as on Windows.
+    """
+    import os
     import sys as _sys
 
-    monkeypatch.setattr(_sys, "frozen", True, raising=False)
-    monkeypatch.setattr(_sys, "executable", r"C:\x\Spirescope.exe", raising=False)
     from sts2 import __main__ as entry
-    importlib.reload(entry)
-    assert entry._program_name() == "Spirescope.exe"
+
+    monkeypatch.setattr(_sys, "frozen", True, raising=False)
+    monkeypatch.setattr(_sys, "executable", os.path.join("anywhere", exe_name))
+    assert entry._program_name() == exe_name
+
     monkeypatch.delattr(_sys, "frozen", raising=False)
-    importlib.reload(entry)
     assert entry._program_name() == "spirescope"


### PR DESCRIPTION
Found while validating the v3.0.5 build on Windows. Both issues are only visible from a packaged build, which is why they survived: a source run renders the correct thing in each case.

## Commands the reader cannot run

Every command the interface suggested assumed a source checkout. A player who downloaded the executable has no Python and no `spirescope` entry point on PATH, so "run `python -m sts2 community`" is an instruction they cannot follow — they have the exe they double-clicked and nothing else. `--help` said `Usage: spirescope` for the same reason.

Commands shown in the UI now go through a `cli` template global naming whichever form the reader actually has, and the help banner names the running executable. Affected: the Community empty state, the stale-data notice on the home page, the Settings localization hint, and four commands in the Guide.

The Guide's Getting Started section now branches on build type. A packaged reader is told to double-click the exe and where to run commands from; the `pip install -e .` and `python -m sts2` instructions stay for source installs.

## The guide described the previous behaviour

It contrasted source installs opening a browser automatically against the packaged build merely keeping a console window open. That stopped being true in #21, when packaged builds started opening the browser too — so the guide contradicted the release it shipped in.

## Verification

Checked against a real packaged build rather than the source tree, since neither defect is observable from source. The rebuilt exe renders `Spirescope.exe community`, `Spirescope.exe update`, `Spirescope.exe update --save-only`, and — under a non-English locale, which is the branch that shows it — `Spirescope.exe localize`. It reports `Usage: Spirescope.exe`. No rendered page contains a source-only command.

785 tests and ruff clean. Three guards added: one rejecting source-only commands in any template, one asserting the Guide keeps both branches with the pip and `python -m` lines confined to the source branch, and one covering the program-name helper in both modes. All three were run against the unfixed files first and fail there.

Also aligns two option lines in `--help` that were indented four spaces where every sibling used two.
