### PR TITLE
Correct the docs against what the code actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ spirescope --version    # Show version
 | `SPIRESCOPE_OPEN_BROWSER` | `1`/`0` override for browser auto-open on `serve` | Enabled |
 | `SPIRESCOPE_CHECK_UPDATES` | `1`/`0` override for automatic GitHub update checks | Source: enabled, frozen build: disabled |
 | `STS2_CORS_ORIGINS` | Comma-separated CORS allowed origins | Localhost only |
+| `STS2_LANG` | Interface language code, e.g. `de` (see [Languages](#languages)) | Settings choice, else `en` |
+| `STS2_STATE_DIR` | Your settings, stats and saved hypotheses | `%APPDATA%\SpireScope`, `~/Library/Application Support/SpireScope`, or `$XDG_DATA_HOME/SpireScope` |
+| `STS2_DATA_DIR` | Game data directory (cards, relics, enemies) | Bundled data; beside the executable in packaged builds |
 
 ### Save File Location
 
@@ -334,6 +337,10 @@ sts2/
   app.py             # FastAPI app, middleware, security headers
   routes.py          # All route handlers
   analytics.py       # Run analytics computation
+  i18n.py            # Interface translation, content overlays
+  localize.py        # Builds translated game text from your install
+  sources.py         # Data source adapters for the update pipeline
+  patches.py         # Patch manifest: what each game version changed
   community/         # Community data (Steam)
     __init__.py      # Orchestrator + re-exports
     _types.py        # Shared types, extraction functions
@@ -349,10 +356,13 @@ sts2/
   sync.py            # Aggregate sync client (upload/download)
   updater.py         # Auto-update checker
   watcher.py         # File watcher with debounce + polling fallback
+  graveyard.py, prophecy.py, hypothesis.py, rivalry.py, cascade.py,
+  ghost.py, drift.py, spectral.py, integrity.py, diagnosis.py,
+  behavior.py, risk.py    # The advanced analytics modules
   data/              # JSON game data + mods
   templates/         # Jinja2 HTML templates (32 templates)
   static/            # CSS, fonts (Cinzel), images, JS
-tests/               # 780 tests (pytest + pytest-asyncio)
+tests/               # 786 tests (pytest + pytest-asyncio)
 ```
 
 ## Requirements

--- a/sts2/templates/guide.html
+++ b/sts2/templates/guide.html
@@ -11,6 +11,7 @@
     <li><a href="#getting-started">Getting Started</a></li>
     <li><a href="#save-files">Save File Setup</a></li>
     <li><a href="#updating-data">Updating Data</a></li>
+    <li><a href="#languages">Languages</a></li>
     <li><a href="#pages">Page Tour</a></li>
     <li><a href="#live">Live Run Tracking</a></li>
     <li><a href="#deck">Deck Analyzer</a></li>
@@ -62,6 +63,14 @@ export STS2_SAVE_DIR=~/.local/share/SlayTheSpire2/steam/YOUR_ID/profile1/saves</
   <p class="text-sm text-muted mt-sm">You can also hot-reload data without restarting by calling <code>POST /api/reload</code> with header <code>X-Admin-Token: YOUR_TOKEN</code>. Set <code>SPIRESCOPE_ADMIN_TOKEN</code> env var or enable debug logging to see the auto-generated token.</p>
 </div>
 
+<h2 id="languages">Languages</h2>
+<div class="card mb-md">
+  <p>Pick a language under <a href="/settings">Settings</a>. That translates the interface &mdash; navigation, buttons, and labels &mdash; and ships in fourteen languages. English and Traditional Chinese are reviewed; the rest are drafts, and corrections are welcome.</p>
+  <p class="mt-sm">Card, relic, potion, enemy, and event text is separate, because that text belongs to the game. To see it in your language, run this once:</p>
+  <pre><code>{{ cli }} localize</code></pre>
+  <p class="text-sm text-muted mt-sm">It reads the language files from the copy of Slay the Spire 2 already installed on this machine &mdash; nothing is downloaded, and the game folder is only read from. Restart Spirescope afterwards and card text follows your language setting, with search matching the translated names. Use <code>{{ cli }} localize --list</code> to see what your install offers, or <code>{{ cli }} localize --lang de,ja</code> for just a few. Anything the game does not translate stays in English.</p>
+</div>
+
 <h2 id="pages">Page Tour</h2>
 <div class="card mb-md">
   <p><strong>Cards</strong> &mdash; Browse all cards with filters by character, type, rarity, cost, and keyword. Click any card for synergies, stats, and community tips.</p>
@@ -73,6 +82,8 @@ export STS2_SAVE_DIR=~/.local/share/SlayTheSpire2/steam/YOUR_ID/profile1/saves</
   <p><strong>Run History</strong> &mdash; All completed runs with floor-by-floor breakdown, HP timeline chart, card picks, cards offered (what you rejected), potions gained, monsters fought, gold per floor, and damage taken. Filter by character, result, ascension, game version, or time range. Export as JSON or standalone HTML. Select two runs to compare side-by-side.</p>
   <p><strong>Analytics</strong> &mdash; Aggregate statistics across all your runs: win rates, character performance, card pick rates, boss matchups, per-character relic tiers, card pick heatmap, and more. Filter by ascension level, game version, or time range.</p>
   <p><strong>Records</strong> &mdash; Personal records: fastest win, highest ascension, best streak, biggest/smallest deck, flawless bosses, per-character breakdowns.</p>
+  <p><strong>Collections</strong> &mdash; How much of the game you have discovered: cards, relics, potions, and events you have encountered, each with a completion percentage and an overall total. Status and Curse cards are excluded, since they are not collectable.</p>
+  <p><strong>Epochs</strong> &mdash; Every epoch with its unlock condition and what it unlocks, filterable by category and character, showing which you have already obtained and when.</p>
   <p><strong>Community</strong> &mdash; Community tier lists and meta discussion from the Steam community.</p>
 </div>
 


### PR DESCRIPTION
A staleness pass over the user-facing documentation, checking each claim against the code rather than reading for plausibility. Covered README.md, the in-app guide, README_DIST.txt, the landing page, and the five files under docs/ — 1,175 lines in total.

## What was wrong

**Three environment variables were undocumented.** `STS2_LANG` sets the interface language, which has had no documentation since localization shipped. `STS2_STATE_DIR` is named as overridable in the v3.0.3 notes but never appeared in the configuration table. `STS2_DATA_DIR` matters for packaged builds, where the data directory sits beside the executable. Defaults in the table were read from `config.py`, not copied from the changelog.

**The guide never mentioned languages.** Not once across 252 lines — so `localize`, and the fourteen languages it enables, were undiscoverable from inside the app. There is now a Languages section, and it uses the same `cli` global as the rest of the guide, so a packaged reader sees `Spirescope.exe localize`.

**The Page Tour skipped two pages that are in the nav.** `/collections` and `/epochs` both exist as routes and had no entry. Their descriptions were written from the route handlers: Collections counts cards, relics, potions and events with a completion percentage and excludes Status and Curse cards; Epochs lists each epoch's unlock condition and rewards, filterable by category and character, showing which were obtained and when.

**Two counts had drifted.** The test count read 780 against an actual 786, and the module listing omitted sixteen modules — including `i18n.py`, `localize.py`, `sources.py` and `patches.py` — while presenting as a complete map.

## What was already correct

All eleven documented API endpoints match the routes exactly, in both directions. All eight CLI commands match. The card count of 639 is exact. No Reddit references survive its retirement in v3.0.3. README_DIST.txt already describes the browser opening by itself and carries the correct Gatekeeper instructions, and its claim that packaged builds skip update checks is borne out by `updater.py`. The landing page links to `releases/latest` and hardcodes no version.

## Verification

786 tests, ruff clean. The guide was rendered from a running server: the new anchor resolves, both new Page Tour entries appear, the localize commands render through the `cli` global, and no unrendered template syntax remains.
