### PR TITLE
Cover the localize text pipeline; raise the coverage gate to 88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
           if [ "${{ matrix.python-version }}" == "3.12" ]; then
             # Coverage gate, calibrated against THIS environment rather than a
             # laptop -- the first version of it was set from a local run and
-            # failed on its first real execution. This leg measured 88.32% when
-            # the floor was set, so 86 leaves the same ~2 points of headroom the
+            # failed on its first real execution. This leg measured 90.48% when
+            # the floor was set, so 88 leaves the same ~2 points of headroom the
             # previous 72-against-74 gate had.
             #
             # That laptop-vs-CI gap used to be ~7 points, almost all of it
@@ -85,7 +85,7 @@ jobs:
             # checkout entirely.
             #
             # Only one leg carries the gate; the other two stay plain pytest.
-            output=$(pytest -q --tb=short --cov=sts2 --cov-branch --cov-fail-under=86 2>&1)
+            output=$(pytest -q --tb=short --cov=sts2 --cov-branch --cov-fail-under=88 2>&1)
           else
             output=$(pytest -q --tb=short 2>&1)
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,15 +68,22 @@ jobs:
         run: |
           set +e
           if [ "${{ matrix.python-version }}" == "3.12" ]; then
-            # Coverage gate. CI measures 74%; a developer machine measures
-            # ~84%, and the difference is not noise: sts2/localize.py is 723
-            # statements that read the installed game's data files, so it
-            # covers 87% where the game exists and 12% here. The threshold is
-            # therefore calibrated against THIS environment, not a laptop --
-            # the first version of this gate was set from a local run and
-            # failed on its first real execution. Only one leg carries it;
-            # the other two stay plain pytest.
-            output=$(pytest -q --tb=short --cov=sts2 --cov-branch --cov-fail-under=72 2>&1)
+            # Coverage gate, calibrated against THIS environment rather than a
+            # laptop -- the first version of it was set from a local run and
+            # failed on its first real execution.
+            #
+            # That laptop-vs-CI gap used to be ~7 points, almost all of it
+            # sts2/localize.py: 723 statements that read the installed game's
+            # data files, so it measured 87% where the game exists and 12%
+            # here. It is now exercised with fixture strings instead (see
+            # tests/test_localize_pipeline.py), so both environments measure
+            # the same code and the two numbers have converged. The only
+            # remaining local-only difference is sts2/risk.py and
+            # sts2/diagnosis.py, which are gitignored and absent from a CI
+            # checkout entirely.
+            #
+            # Only one leg carries the gate; the other two stay plain pytest.
+            output=$(pytest -q --tb=short --cov=sts2 --cov-branch --cov-fail-under=84 2>&1)
           else
             output=$(pytest -q --tb=short 2>&1)
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
           if [ "${{ matrix.python-version }}" == "3.12" ]; then
             # Coverage gate, calibrated against THIS environment rather than a
             # laptop -- the first version of it was set from a local run and
-            # failed on its first real execution.
+            # failed on its first real execution. This leg measured 88.32% when
+            # the floor was set, so 86 leaves the same ~2 points of headroom the
+            # previous 72-against-74 gate had.
             #
             # That laptop-vs-CI gap used to be ~7 points, almost all of it
             # sts2/localize.py: 723 statements that read the installed game's
@@ -83,7 +85,7 @@ jobs:
             # checkout entirely.
             #
             # Only one leg carries the gate; the other two stay plain pytest.
-            output=$(pytest -q --tb=short --cov=sts2 --cov-branch --cov-fail-under=84 2>&1)
+            output=$(pytest -q --tb=short --cov=sts2 --cov-branch --cov-fail-under=86 2>&1)
           else
             output=$(pytest -q --tb=short 2>&1)
           fi

--- a/sts2/behavior.py
+++ b/sts2/behavior.py
@@ -11,10 +11,10 @@ def detect_tilt(runs, session_window_hours=4):
     if len(runs) < 3:
         return {"tilting": False, "momentum": 0, "message": ""}
 
-    sessions = _group_sessions(runs, session_window_hours)
-    current = sessions[-1] if sessions else runs[-5:]
-    if not current:
-        return {"tilting": False, "momentum": 0, "message": ""}
+    # runs is non-empty (guarded above) and _group_sessions always returns at
+    # least one non-empty session for non-empty input, so the most recent
+    # session is always present and always has runs in it.
+    current = _group_sessions(runs, session_window_hours)[-1]
 
     avg_floors = _avg_last_floor(current)
     hist_avg = _avg_last_floor(runs)

--- a/sts2/localize.py
+++ b/sts2/localize.py
@@ -722,7 +722,7 @@ def _build_all():
     log.debug("TOKEN-NAME CHECK on 20 random cards: "
           f"{len(mismatches)} languages x entities with token names not in English")
     for mm in mismatches:
-        log.debug("   ", mm)
+        log.debug("   %s", mm)
 
     # ---- English alignment pass (once) ----
     # aligned[(section, shipped_id)] = dict(variant -> (values, branches) or None)
@@ -759,15 +759,22 @@ def _build_all():
                 variants["base"] = res
             if section == "cards":
                 up = item.get("description_upgraded", "") or ""
-                if not needs_alignment(tpl):
+                if not up:
+                    # No upgraded English means there is nothing to translate.
+                    # This has to be checked before the no-alignment shortcut
+                    # below: card_detail.html renders an "Upgraded:" block
+                    # whenever the field is present, so filling it in anyway
+                    # showed translated players a section English readers
+                    # never see (6 cards x 13 languages), restating the base
+                    # description back at them.
+                    variants["up"] = None
+                elif not needs_alignment(tpl):
                     variants["up"] = ({}, {}, {})
-                elif up:
+                else:
                     upres = extract_english(tpl, up)
                     if upres is None:
                         upres = fallback_single_number(tpl, up)
                     variants["up"] = upres
-                else:
-                    variants["up"] = None
             aligned[(section, sid)] = variants
             if variants["base"] is not None:
                 stats_align[section][0] += 1

--- a/sts2/templates/card_detail.html
+++ b/sts2/templates/card_detail.html
@@ -19,7 +19,16 @@
 </div>
 
 <div class="detail-desc">{{ card.description }}</div>
-{% if card.description_upgraded %}
+{# Same guard the deck popover already applies (deck.js): an "Upgraded:" block
+   repeating the base description tells the reader nothing. It happens in
+   English wherever the wiki records identical text, and in translations
+   wherever the difference is a keyword prefix (Retain./Innate./Exhaust.) that
+   lives in card metadata rather than in the game's description template, so
+   the localized template cannot express it. Suppressing it here rather than
+   in the overlay is deliberate: an overlay that omits the field falls back to
+   the English string (knowledge.py skips absent values), which would put
+   English upgrade text under a translated description. #}
+{% if card.description_upgraded and card.description_upgraded != card.description %}
 <div class="detail-desc card-win"><strong class="text-green">Upgraded:</strong> {{ card.description_upgraded }}</div>
 {% endif %}
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -638,6 +638,39 @@ async def test_card_detail_no_stats_when_empty(client):
         assert "Your Stats" not in resp.text
 
 
+async def test_card_detail_hides_an_upgraded_block_that_repeats_the_base(client):
+    """An "Upgraded:" section identical to the description tells the reader
+    nothing. It happens in English wherever the wiki records the same text for
+    both, and in translations wherever the difference is a keyword prefix
+    (Retain./Innate./Exhaust.) that the game's description template does not
+    carry. deck.js already applied this guard; the detail page did not.
+
+    Suppressing it here rather than in the localize overlay is deliberate:
+    knowledge.py skips absent overlay fields, so an overlay that dropped the
+    field would leave the *English* upgrade text under a translated
+    description.
+    """
+    from unittest.mock import patch
+
+    from sts2.app import kb as _kb
+
+    card = next(c for c in _kb.cards if c.id == "CARD.BASH")
+    same = card.model_copy(update={"description": "Deal 8 damage.",
+                                   "description_upgraded": "Deal 8 damage."})
+    differs = card.model_copy(update={"description": "Deal 8 damage.",
+                                      "description_upgraded": "Deal 10 damage."})
+
+    # the route resolves through the id index, not by scanning kb.cards
+    with patch.object(_kb, "get_card_by_id", return_value=same):
+        body = (await client.get("/cards/CARD.BASH")).text
+    assert "Upgraded:" not in body
+
+    with patch.object(_kb, "get_card_by_id", return_value=differs):
+        body = (await client.get("/cards/CARD.BASH")).text
+    assert "Upgraded:" in body
+    assert "Deal 10 damage." in body
+
+
 async def test_index_shows_character_streaks(client):
     """Index page should show streak/ascension info when available."""
     from unittest.mock import AsyncMock, patch

--- a/tests/test_app_internals.py
+++ b/tests/test_app_internals.py
@@ -1,0 +1,273 @@
+"""Lifespan, the save watcher, the log poller and the last-resort error handler.
+
+None of this is reachable through the test client's normal request path: the
+lifespan only runs when a real server starts, the watcher and log poller are
+background coroutines, and the global exception handler exists precisely for
+the requests that never reach a route. All four fail silently by design --
+they swallow exceptions so a bad save file or a locked log cannot take the
+dashboard down -- which also means a break in them is invisible.
+"""
+import asyncio
+
+import pytest
+
+from sts2 import app as app_module
+
+# ------------------------------------------------------------------ lifespan
+
+async def test_lifespan_starts_the_watcher_and_stops_it_again(monkeypatch):
+    """Nothing used to run after yield: the watcher task was never cancelled
+    and the observer threads were never stopped or joined, so shutdown relied
+    on daemon threads dying with the process."""
+    started = {}
+
+    async def fake_watch():
+        started["watching"] = True
+        await asyncio.Event().wait()          # never completes on its own
+
+    monkeypatch.setattr(app_module, "_watch_saves", fake_watch)
+    monkeypatch.setattr(app_module, "_prewarm_caches", lambda: asyncio.sleep(0))
+    monkeypatch.setattr("sts2.updater.check_for_update", lambda _v: None)
+    monkeypatch.setattr("sts2.updater.check_for_data_update", lambda: None)
+
+    stopped, joined = [], []
+
+    class _Observer:
+        def stop(self):
+            stopped.append(True)
+
+        def join(self, _timeout):
+            joined.append(True)
+
+    monkeypatch.setattr(app_module, "_observers", [_Observer()])
+
+    async with app_module._lifespan(app_module.app):
+        await asyncio.sleep(0)
+        assert started.get("watching")
+
+    assert stopped == [True], "observer threads must be stopped on shutdown"
+    assert joined == [True], "and joined, not left to die with the process"
+    assert app_module._observers == []
+
+
+async def test_lifespan_survives_an_observer_that_refuses_to_stop(monkeypatch):
+    """A wedged observer must not stop the rest of shutdown."""
+    monkeypatch.setattr(app_module, "_watch_saves",
+                        lambda: asyncio.Event().wait())
+    monkeypatch.setattr(app_module, "_prewarm_caches", lambda: asyncio.sleep(0))
+    monkeypatch.setattr("sts2.updater.check_for_update", lambda _v: None)
+    monkeypatch.setattr("sts2.updater.check_for_data_update", lambda: None)
+
+    class _Bad:
+        def stop(self):
+            raise RuntimeError("wedged")
+
+        def join(self, _timeout):
+            raise RuntimeError("wedged")
+
+    monkeypatch.setattr(app_module, "_observers", [_Bad()])
+    async with app_module._lifespan(app_module.app):
+        pass
+    assert app_module._observers == []
+
+
+# ------------------------------------------------------------ cache pre-warm
+
+async def test_prewarm_populates_the_progress_and_run_caches(monkeypatch):
+    from sts2.models import PlayerProgress
+    progress = PlayerProgress()
+    runs = []
+    monkeypatch.setattr(app_module, "get_progress", lambda: progress)
+    monkeypatch.setattr(app_module, "get_run_history", lambda: runs)
+    monkeypatch.setattr(app_module, "_progress_cache", None)
+    await app_module._prewarm_caches()
+    assert app_module._progress_cache is progress
+
+
+async def test_prewarm_failure_never_stops_startup(monkeypatch, caplog):
+    """A corrupt save file at startup would otherwise abort the lifespan and
+    the server would never come up at all."""
+    def boom():
+        raise OSError("save file locked")
+
+    monkeypatch.setattr(app_module, "get_progress", boom)
+    await app_module._prewarm_caches()          # must not raise
+
+
+# --------------------------------------------------------------- mtime scan
+
+def test_check_mtime_is_zero_when_no_save_tree_exists(monkeypatch, tmp_path):
+    monkeypatch.setattr(app_module, "SAVE_DIRS", [tmp_path / "absent"])
+    assert app_module._check_mtime() == 0.0
+
+
+def test_check_mtime_spans_every_detected_save_tree(monkeypatch, tmp_path):
+    """History merges the vanilla and modded trees, but change detection used
+    to watch only whichever was freshest at startup -- switching between them
+    mid-session left the dashboard blind to the active one."""
+    import os
+    vanilla, modded = tmp_path / "vanilla", tmp_path / "modded"
+    for d, mtime in ((vanilla, 1_000), (modded, 9_000)):
+        (d / "history").mkdir(parents=True)
+        progress = d / "progress.save"
+        progress.write_text("{}", encoding="utf-8")
+        os.utime(progress, (mtime, mtime))
+        run = d / "history" / "1.run"
+        run.write_text("{}", encoding="utf-8")
+        os.utime(run, (mtime, mtime))
+    monkeypatch.setattr(app_module, "SAVE_DIRS", [vanilla, modded])
+    assert app_module._check_mtime() >= 9_000
+
+
+def test_check_mtime_skips_a_run_file_it_cannot_stat(monkeypatch, tmp_path):
+    """A file deleted between glob() and stat() is normal while the game is
+    writing; it must not abort the whole scan."""
+    from pathlib import Path
+    (tmp_path / "history").mkdir()
+    (tmp_path / "history" / "1.run").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(app_module, "SAVE_DIRS", [tmp_path])
+    real_stat = Path.stat
+
+    def flaky(self, *a, **kw):
+        if self.suffix == ".run":
+            raise OSError("vanished mid-scan")
+        return real_stat(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "stat", flaky)
+    assert app_module._check_mtime() >= 0.0     # must not raise
+
+
+# ------------------------------------------------------------- log tailer
+
+class _Tailer:
+    def __init__(self, result=None, state=None):
+        self._result = result
+        self.state = state
+
+    def poll(self):
+        return self._result
+
+
+class _State:
+    def __init__(self, active):
+        self.active = active
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_state(monkeypatch):
+    monkeypatch.setattr(app_module, "_log_tailer", None)
+    monkeypatch.setattr(app_module, "_log_run_state", None)
+    monkeypatch.setattr(app_module, "_log_poll_lock", None)
+
+
+async def test_polling_the_log_records_a_live_run(monkeypatch):
+    class _Result:
+        @staticmethod
+        def model_dump():
+            return {"active": True, "floor": 7}
+
+    monkeypatch.setattr(app_module, "_log_tailer", _Tailer(_Result()))
+    await app_module._poll_game_log_once()
+    assert app_module._log_run_state == {"active": True, "floor": 7}
+
+
+async def test_polling_accepts_a_tailer_that_offers_to_dict(monkeypatch):
+    class _Result:
+        @staticmethod
+        def to_dict():
+            return {"active": True, "floor": 3}
+
+    monkeypatch.setattr(app_module, "_log_tailer", _Tailer(_Result()))
+    await app_module._poll_game_log_once()
+    assert app_module._log_run_state == {"active": True, "floor": 3}
+
+
+async def test_a_plain_dict_result_is_stored_as_is(monkeypatch):
+    monkeypatch.setattr(app_module, "_log_tailer", _Tailer({"active": True}))
+    await app_module._poll_game_log_once()
+    assert app_module._log_run_state == {"active": True}
+
+
+async def test_a_finished_run_clears_the_live_state(monkeypatch):
+    """The tailer stops returning results once the run ends; without this the
+    dashboard keeps showing the last floor of a run that is already over."""
+    monkeypatch.setattr(app_module, "_log_run_state", {"active": True})
+    monkeypatch.setattr(app_module, "_log_tailer",
+                        _Tailer(None, state=_State(active=False)))
+    await app_module._poll_game_log_once()
+    assert app_module._log_run_state is None
+
+
+async def test_no_result_and_no_previous_run_changes_nothing(monkeypatch):
+    monkeypatch.setattr(app_module, "_log_tailer",
+                        _Tailer(None, state=_State(active=False)))
+    await app_module._poll_game_log_once()
+    assert app_module._log_run_state is None
+
+
+async def test_a_tailer_that_raises_never_reaches_the_request(monkeypatch):
+    """The log lives in the game's directory and can be locked or half-written
+    at any moment; that must not turn into a 500 on the live page."""
+    class _Boom:
+        state = None
+
+        def poll(self):
+            raise OSError("log file locked by the game")
+
+    monkeypatch.setattr(app_module, "_log_tailer", _Boom())
+    await app_module._poll_game_log_once()      # must not raise
+
+
+async def test_the_poller_builds_its_own_tailer_on_first_use(monkeypatch):
+    built = {}
+
+    class _Fake:
+        state = None
+
+        def __init__(self):
+            built["yes"] = True
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr("sts2.logparser.LogTailer", _Fake)
+    await app_module._poll_game_log_once()
+    assert built.get("yes")
+    assert app_module._log_tailer is not None
+
+
+# --------------------------------------------------- last-resort error handler
+
+def _request(path="/boom", accept="text/html"):
+    from starlette.requests import Request
+    return Request({
+        "type": "http", "http_version": "1.1", "method": "GET", "path": path,
+        "raw_path": path.encode(), "root_path": "", "query_string": b"",
+        "headers": [(b"accept", accept.encode())], "app": app_module.app,
+        "scheme": "http", "server": ("testserver", 80), "client": ("test", 1),
+    })
+
+
+async def test_an_unhandled_error_renders_the_error_page(caplog):
+    resp = await app_module.global_error_handler(
+        _request(), RuntimeError("kaboom"))
+    assert resp.status_code == 500
+    assert b"Something went wrong" in resp.body
+
+
+async def test_an_unhandled_error_on_an_api_path_returns_json():
+    resp = await app_module.global_error_handler(
+        _request("/api/cards", accept="application/json"), RuntimeError("x"))
+    assert resp.status_code == 500
+    assert b'"status":500' in resp.body.replace(b" ", b"")
+
+
+async def test_the_logged_path_is_sanitised(caplog):
+    """The path reaches the log verbatim otherwise, so a crafted URL could
+    inject newlines into the log stream."""
+    import logging
+    caplog.set_level(logging.ERROR)
+    await app_module.global_error_handler(
+        _request("/boom\r\nFAKE-LOG-LINE"), RuntimeError("x"))
+    assert "FAKE-LOG-LINE" in caplog.text        # still present...
+    assert "\r\n" not in caplog.text.split("FAKE")[0][-40:]  # ...but not as a break

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1,0 +1,415 @@
+"""Tilt detection, anti-pattern scanning and decision-quality scoring.
+
+Every prior reference to this module was a mock asserting `mock.called`, so
+each function could have returned a constant and the suite would have stayed
+green. These tests assert computed values and contrast inputs that must give
+different answers.
+
+The two statistics at the bottom (`_consistency_index`, `_diversity_score`)
+are checked against the mathematical properties that define them -- a Hurst
+R/S exponent tends to 1 for a pure trend, and a sample entropy is 0 for a
+constant series -- rather than against numbers copied out of a previous run,
+which would only pin whatever the code happened to do.
+"""
+import math
+
+import pytest
+
+from sts2.behavior import (
+    _avg_last_floor,
+    _consistency_index,
+    _count_trailing_losses,
+    _diversity_score,
+    _encode_decisions,
+    _group_sessions,
+    _std,
+    decision_quality_profile,
+    detect_anti_patterns,
+    detect_tilt,
+)
+from sts2.models import RunFloor, RunHistory
+
+HOUR = 3600
+
+
+def _floor(n, ftype="monster", dmg=0, gained=(), used=(), pick="", max_hp=80):
+    return RunFloor(floor=n, type=ftype, damage_taken=dmg, max_hp=max_hp,
+                    potions_gained=list(gained), potions_used=list(used),
+                    card_picked=pick)
+
+
+def _run(rid, win=False, ts=1_700_000_000, floors=None, deck=None, run_time=600):
+    return RunHistory(id=rid, character="Ironclad", win=win, timestamp=ts,
+                      run_time=run_time, deck=deck or ["CARD.STRIKE"] * 10,
+                      floors=floors if floors is not None else [_floor(1)])
+
+
+def _climb(rid, top, **kw):
+    """A run that reached `top` floors."""
+    return _run(rid, floors=[_floor(i) for i in range(1, top + 1)], **kw)
+
+
+# ------------------------------------------------------------------- helpers
+
+def test_group_sessions_splits_on_a_gap_longer_than_the_window():
+    runs = [_run("a", ts=0), _run("b", ts=HOUR), _run("c", ts=HOUR * 10)]
+    sessions = _group_sessions(runs, window_hours=4)
+    assert [[r.id for r in s] for s in sessions] == [["a", "b"], ["c"]]
+
+
+def test_group_sessions_orders_by_timestamp_before_grouping():
+    """Run history is not guaranteed sorted; grouping unsorted input would
+    scatter one sitting across several "sessions"."""
+    runs = [_run("c", ts=HOUR * 10), _run("a", ts=0), _run("b", ts=HOUR)]
+    assert [[r.id for r in s] for s in _group_sessions(runs, 4)] == [["a", "b"], ["c"]]
+
+
+def test_group_sessions_of_nothing_is_nothing():
+    assert _group_sessions([], 4) == []
+
+
+def test_avg_last_floor_uses_the_final_floor_of_each_run():
+    assert _avg_last_floor([_climb("a", 10), _climb("b", 20)]) == 15
+
+
+def test_avg_last_floor_of_runs_without_floors_is_zero():
+    assert _avg_last_floor([_run("a", floors=[])]) == 0
+
+
+def test_count_trailing_losses_stops_at_the_most_recent_win():
+    runs = [_run("a"), _run("b", win=True), _run("c"), _run("d")]
+    assert _count_trailing_losses(runs) == 2
+
+
+def test_count_trailing_losses_counts_every_run_when_none_were_won():
+    assert _count_trailing_losses([_run("a"), _run("b")]) == 2
+
+
+# --------------------------------------------------------------------- tilt
+
+def test_tilt_needs_at_least_three_runs():
+    assert detect_tilt([_run("a"), _run("b")]) == {
+        "tilting": False, "momentum": 0, "message": ""}
+
+
+def test_tilt_fires_when_the_current_session_collapses_against_history():
+    """The signal is a session far below the player's own baseline -- not an
+    absolute floor number, which would just flag every new player."""
+    good = [_climb("g%d" % i, 30, ts=i * HOUR, win=True) for i in range(3)]
+    bad = [_climb("b%d" % i, 4, ts=HOUR * 100 + i * HOUR) for i in range(3)]
+    result = detect_tilt(good + bad)
+    assert result["tilting"] is True
+    assert result["momentum"] <= -70          # -40 collapse, -30 three losses
+    assert result["consecutive_losses"] == 3
+    assert result["session_avg_floor"] == 4.0
+    assert result["historical_avg_floor"] == 17.0
+    assert "Consider taking a break" in result["message"]
+
+
+def test_tilt_deepens_after_five_straight_losses():
+    short = detect_tilt([_climb("b%d" % i, 4, ts=HOUR * 100 + i * HOUR)
+                         for i in range(3)])
+    long = detect_tilt([_climb("b%d" % i, 4, ts=HOUR * 100 + i * HOUR)
+                        for i in range(5)])
+    assert long["momentum"] < short["momentum"]
+
+
+def test_tilt_penalises_sessions_whose_runs_keep_getting_shorter():
+    """Rage-quitting earlier and earlier is the behavioural tell; a session of
+    equal-length runs with the same results must not score the same."""
+    steady = [_climb("s%d" % i, 10, ts=i * HOUR, run_time=1000) for i in range(3)]
+    quitting = [_climb("q%d" % i, 10, ts=i * HOUR, run_time=t)
+                for i, t in enumerate((1000, 800, 100))]
+    assert detect_tilt(quitting)["momentum"] < detect_tilt(steady)["momentum"]
+
+
+def test_a_win_lifts_momentum():
+    losses = [_climb("l%d" % i, 10, ts=i * HOUR) for i in range(3)]
+    ending_in_a_win = losses[:2] + [_climb("w", 10, ts=2 * HOUR, win=True)]
+    assert detect_tilt(ending_in_a_win)["momentum"] > detect_tilt(losses)["momentum"]
+
+
+def test_a_session_of_one_or_two_runs_is_not_yet_a_pattern():
+    """Two bad runs after a break is noise. Without this credit the tool would
+    tell someone to take a break they just came back from."""
+    history = [_climb("h%d" % i, 30, ts=i * HOUR, win=True) for i in range(4)]
+    fresh = [_climb("n", 3, ts=HOUR * 500)]
+    assert detect_tilt(history + fresh)["momentum"] >= -30
+    assert detect_tilt(history + fresh)["tilting"] is False
+
+
+def test_tilt_reports_no_message_when_not_tilting():
+    winners = [_climb("w%d" % i, 40, ts=i * HOUR, win=True) for i in range(4)]
+    result = detect_tilt(winners)
+    assert result["tilting"] is False
+    assert result["message"] == ""
+
+
+# ------------------------------------------------------------ anti-patterns
+
+def test_anti_patterns_need_at_least_five_runs():
+    assert detect_anti_patterns([_run(str(i)) for i in range(4)]) == []
+
+
+def _named(patterns):
+    return {p["name"] for p in patterns}
+
+
+def test_the_hoarder_fires_on_repeated_deaths_with_unused_potions():
+    runs = [_run("h%d" % i, floors=[_floor(1, gained=("P1", "P2"))])
+            for i in range(3)]
+    runs += [_run("ok%d" % i, floors=[_floor(1, gained=("P1",), used=("P1",))])
+             for i in range(3)]
+    patterns = detect_anti_patterns(runs)
+    assert "The Hoarder" in _named(patterns)
+    hoarder = next(p for p in patterns if p["name"] == "The Hoarder")
+    assert hoarder["stat"] == "3/6 deaths"
+    assert hoarder["severity"] == "warning"
+
+
+def test_the_hoarder_stays_quiet_when_potions_get_used():
+    runs = [_run("u%d" % i, floors=[_floor(1, gained=("P1", "P2"), used=("P1",))])
+            for i in range(6)]
+    assert "The Hoarder" not in _named(detect_anti_patterns(runs))
+
+
+def test_the_greedy_builder_compares_losing_decks_against_winning_ones():
+    losses = [_run("l%d" % i, deck=["CARD.X"] * 40) for i in range(3)]
+    wins = [_run("w%d" % i, win=True, deck=["CARD.X"] * 20) for i in range(3)]
+    patterns = detect_anti_patterns(losses + wins)
+    greedy = next(p for p in patterns if p["name"] == "The Greedy Builder")
+    assert greedy["stat"] == "40 vs 20 cards"
+    assert greedy["severity"] == "warning"
+
+
+def test_the_greedy_builder_falls_back_to_an_absolute_size_without_any_wins():
+    """A player with no wins has no personal baseline to compare against, so
+    the check becomes advisory rather than a warning."""
+    losses = [_run("l%d" % i, deck=["CARD.X"] * 35) for i in range(5)]
+    greedy = next(p for p in detect_anti_patterns(losses)
+                  if p["name"] == "The Greedy Builder")
+    assert greedy["severity"] == "info"
+    assert greedy["stat"] == "avg 35 cards"
+
+
+def test_a_modest_deck_with_no_wins_is_not_flagged():
+    losses = [_run("l%d" % i, deck=["CARD.X"] * 20) for i in range(5)]
+    assert "The Greedy Builder" not in _named(detect_anti_patterns(losses))
+
+
+def test_the_coward_fires_when_elites_are_a_tiny_share_of_fights():
+    floors = [_floor(i) for i in range(1, 26)]          # 25 monster fights
+    runs = [_run("r%d" % i, floors=floors) for i in range(5)]
+    coward = next(p for p in detect_anti_patterns(runs) if p["name"] == "The Coward")
+    assert coward["stat"] == "0% elite rate"
+    assert coward["severity"] == "info"
+
+
+def test_the_coward_stays_quiet_for_a_healthy_elite_rate():
+    floors = [_floor(i, ftype="elite" if i % 4 == 0 else "monster")
+              for i in range(1, 26)]
+    runs = [_run("r%d" % i, floors=floors) for i in range(5)]
+    assert "The Coward" not in _named(detect_anti_patterns(runs))
+
+
+def test_the_coward_needs_a_meaningful_sample_of_fights():
+    """Under 20 combats the rate is noise, so nothing is claimed."""
+    floors = [_floor(i) for i in range(1, 4)]
+    runs = [_run("r%d" % i, floors=floors) for i in range(5)]
+    assert "The Coward" not in _named(detect_anti_patterns(runs))
+
+
+def test_potion_paralysis_fires_when_most_deaths_leave_potions_unspent():
+    runs = [_run("p%d" % i, floors=[_floor(1, gained=("A", "B", "C"), used=("A",))])
+            for i in range(6)]
+    paralysis = next(p for p in detect_anti_patterns(runs)
+                     if p["name"] == "Potion Paralysis")
+    assert paralysis["stat"] == "6/6 deaths"
+    assert "100%" in paralysis["description"]
+
+
+def test_potion_paralysis_needs_more_than_five_deaths():
+    runs = [_run("p%d" % i, floors=[_floor(1, gained=("A", "B", "C"))])
+            for i in range(5)]
+    assert "Potion Paralysis" not in _named(detect_anti_patterns(runs))
+
+
+def test_a_clean_history_reports_no_anti_patterns():
+    runs = [_run("w%d" % i, win=True, deck=["CARD.X"] * 15,
+                 floors=[_floor(1, ftype="elite")]) for i in range(6)]
+    assert detect_anti_patterns(runs) == []
+
+
+# ----------------------------------------------------------- decision coding
+
+class _StubKB:
+    def __init__(self, types):
+        self._types = types
+
+    def get_card_by_id(self, cid):
+        kind = self._types.get(cid)
+        if kind is None:
+            return None
+        return type("Card", (), {"type": kind})()
+
+
+def test_encode_decisions_scores_floor_types():
+    floors = [_floor(1, ftype=t) for t in
+              ("monster", "elite", "boss", "shop", "rest", "event", "treasure")]
+    assert _encode_decisions(_run("a", floors=floors), None) == [1, 3, 5, 2, 2, 1, 1]
+
+
+def test_encode_decisions_scores_an_unknown_floor_type_as_one():
+    assert _encode_decisions(_run("a", floors=[_floor(1, ftype="wormhole")]),
+                             None) == [1]
+
+
+def test_encode_decisions_adds_a_bonus_for_the_card_type_picked():
+    kb = _StubKB({"CARD.A": "Attack", "CARD.S": "Skill", "CARD.P": "Power",
+                  "CARD.C": "Curse"})
+    floors = [_floor(1, pick=c) for c in ("CARD.A", "CARD.S", "CARD.P", "CARD.C")]
+    assert _encode_decisions(_run("a", floors=floors), kb) == [2, 3, 4, 1]
+
+
+def test_encode_decisions_ignores_a_card_the_knowledge_base_does_not_know():
+    kb = _StubKB({})
+    assert _encode_decisions(_run("a", floors=[_floor(1, pick="CARD.MOD")]), kb) == [1]
+
+
+def test_encode_decisions_ignores_picks_when_there_is_no_knowledge_base():
+    assert _encode_decisions(_run("a", floors=[_floor(1, pick="CARD.A")]), None) == [1]
+
+
+def test_encode_decisions_adds_a_signal_proportional_to_damage_taken():
+    floors = [_floor(1, dmg=0, max_hp=80), _floor(2, dmg=40, max_hp=80),
+              _floor(3, dmg=80, max_hp=80)]
+    assert _encode_decisions(_run("a", floors=floors), None) == [1, 1 + 2, 1 + 5]
+
+
+def test_encode_decisions_ignores_damage_when_max_hp_is_unknown():
+    assert _encode_decisions(_run("a", floors=[_floor(1, dmg=40, max_hp=0)]),
+                             None) == [1]
+
+
+# ------------------------------------------------------------- the statistics
+
+def test_std_of_a_constant_series_is_zero():
+    assert _std([4, 4, 4, 4]) == 0
+
+
+def test_std_matches_the_population_definition():
+    # population std of 2,4,4,4,5,5,7,9 is exactly 2
+    assert _std([2, 4, 4, 4, 5, 5, 7, 9]) == pytest.approx(2.0)
+
+
+def test_std_of_fewer_than_two_points_is_zero():
+    assert _std([5]) == 0
+    assert _std([]) == 0
+
+
+def test_consistency_of_a_short_series_is_the_neutral_default():
+    assert _consistency_index([1, 2, 3]) == 0.5
+
+
+def test_consistency_of_a_flat_series_is_the_neutral_default():
+    """A run with no variation has no rescaled range to measure; returning the
+    midpoint keeps it out of both the "formulaic" and "chaotic" buckets."""
+    assert _consistency_index([3] * 20) == 0.5
+
+
+@pytest.mark.parametrize("n", [10, 20, 40, 100])
+def test_consistency_of_a_pure_trend_matches_the_closed_form(n):
+    """Validated against the analytic value rather than a recorded output.
+
+    For the ramp 1..n the cumulative deviation is S_k = k(k-n)/2, so it peaks
+    at 0 (k=n) and bottoms at -n^2/8 (k=n/2), giving R = n^2/8 exactly, while
+    S is the population standard deviation sqrt((n^2-1)/12). Anything that
+    quietly changes the estimator -- sample vs population variance, a
+    different cumulative-deviation convention -- breaks this equality.
+    """
+    R = n * n / 8
+    S = math.sqrt((n * n - 1) / 12)
+    assert _consistency_index(list(range(1, n + 1))) == pytest.approx(
+        math.log(R / S) / math.log(n))
+
+
+def test_consistency_of_a_trend_rises_slowly_towards_one_with_length():
+    """The Hurst exponent of a deterministic ramp tends to 1, but only as
+    log(0.433n)/log(n) -- it is still ~0.77 at n=40, which is why this is a
+    monotonicity check and not an assertion that it is close to 1."""
+    assert (_consistency_index(list(range(1, 21)))
+            < _consistency_index(list(range(1, 41)))
+            < _consistency_index(list(range(1, 201))) < 1)
+
+
+def test_a_trend_scores_higher_than_an_alternating_series():
+    trend = _consistency_index(list(range(1, 41)))
+    alternating = _consistency_index([1, 2] * 20)
+    assert trend > alternating
+
+
+def test_diversity_of_a_constant_series_is_zero():
+    """Sample entropy of a series with no variation is 0 by definition."""
+    assert _diversity_score([7] * 30) == 0
+
+
+def test_diversity_of_too_short_a_series_is_zero():
+    assert _diversity_score([1, 2, 3], m=2) == 0
+
+
+def test_diversity_of_a_repeating_pattern_is_lower_than_of_a_varied_one():
+    periodic = _diversity_score([1, 2, 3] * 10)
+    varied = _diversity_score([1, 9, 2, 8, 3, 7, 1, 6, 4, 2, 9, 5,
+                               3, 8, 1, 7, 2, 6, 4, 9, 5, 3, 8, 2,
+                               7, 1, 6, 9, 4, 5])
+    assert varied > periodic
+
+
+def test_diversity_is_non_negative_and_finite():
+    score = _diversity_score([1, 3, 2, 5, 4, 2, 6, 1, 3, 5, 2, 4, 6, 1, 3])
+    assert score >= 0 and math.isfinite(score)
+
+
+# ------------------------------------------------------- decision classification
+
+def _run_with_floors(n):
+    return _run("a", floors=[_floor(i) for i in range(1, n + 1)])
+
+
+def test_decision_profile_needs_ten_decisions():
+    assert decision_quality_profile(_run_with_floors(5)) == {
+        "classification": "insufficient_data", "consistency": 0, "diversity": 0}
+
+
+@pytest.mark.parametrize("consistency, diversity, expected", [
+    (1.5, 0.8, "formulaic"),      # consistency dominates
+    (0.2, 0.8, "chaotic"),
+    (0.8, 0.1, "rigid"),
+    (0.8, 1.5, "adaptive"),
+    (0.8, 0.8, "strategic"),
+    # boundaries: the thresholds are exclusive on both sides
+    (1.2, 0.8, "strategic"),
+    (0.4, 0.8, "strategic"),
+])
+def test_decision_profile_classifies_by_consistency_then_diversity(
+        monkeypatch, consistency, diversity, expected):
+    monkeypatch.setattr("sts2.behavior._consistency_index", lambda _s: consistency)
+    monkeypatch.setattr("sts2.behavior._diversity_score", lambda _s, m=2: diversity)
+    profile = decision_quality_profile(_run_with_floors(12))
+    assert profile["classification"] == expected
+    assert profile["consistency"] == round(consistency, 3)
+    assert profile["diversity"] == round(diversity, 3)
+
+
+def test_decision_profile_runs_end_to_end_on_a_real_run():
+    """No monkeypatching: a varied run must produce a real classification and
+    finite statistics."""
+    floors = [_floor(i, ftype=t, dmg=d) for i, (t, d) in enumerate(
+        [("monster", 5), ("elite", 20), ("rest", 0), ("monster", 8),
+         ("shop", 0), ("monster", 12), ("elite", 25), ("event", 0),
+         ("monster", 3), ("boss", 40), ("rest", 0), ("monster", 7)], start=1)]
+    profile = decision_quality_profile(_run("a", floors=floors))
+    assert profile["classification"] in {
+        "formulaic", "chaotic", "rigid", "adaptive", "strategic"}
+    assert math.isfinite(profile["consistency"])
+    assert math.isfinite(profile["diversity"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 """Tests for the CLI entry point (__main__.py)."""
+import os
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -220,3 +221,228 @@ def test_should_open_browser_flag_override():
     with patch.object(sys, "frozen", True, create=True), \
          patch.dict("os.environ", {"SPIRESCOPE_OPEN_BROWSER": "0"}, clear=False):
         assert _should_open_browser(["--browser"]) is True
+
+
+# ── Environment flag parsing ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("raw, expected", [
+    ("1", True), ("true", True), ("YES", True), (" On ", True),
+    ("0", False), ("false", False), ("no", False), ("OFF", False),
+    ("maybe", None), ("", None),
+])
+def test_env_flag_reads_the_usual_spellings(raw, expected):
+    """An unrecognised value must read as "unset", not as False -- otherwise a
+    typo silently turns a feature off instead of falling through to the
+    default."""
+    from sts2.__main__ import _env_flag
+    with patch.dict("os.environ", {"SPIRESCOPE_TEST_FLAG": raw}, clear=False):
+        assert _env_flag("SPIRESCOPE_TEST_FLAG") is expected
+
+
+def test_env_flag_of_an_unset_variable_is_none():
+    from sts2.__main__ import _env_flag
+    with patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("SPIRESCOPE_TEST_FLAG", None)
+        assert _env_flag("SPIRESCOPE_TEST_FLAG") is None
+
+
+# ── Program name in the help text ────────────────────────────────────────
+
+def test_program_name_matches_a_packaged_build():
+    """A packaged build has no `spirescope` on PATH, so printing that name
+    tells the reader to run something they do not have."""
+    from sts2.__main__ import _program_name
+    with patch.object(sys, "frozen", True, create=True), \
+         patch.object(sys, "executable", r"C:\Games\Spirescope\Spirescope.exe"):
+        assert _program_name() == "Spirescope.exe"
+
+
+def test_program_name_of_a_source_checkout_is_the_entry_point():
+    from sts2.__main__ import _program_name
+    with patch.object(sys, "frozen", False, create=True):
+        assert _program_name() == "spirescope"
+
+
+# ── Rarity canonicalization after a wiki refresh ─────────────────────────
+
+def test_rarity_canonicalization_is_a_no_op_when_the_script_is_absent():
+    """Frozen builds ship no scripts/ directory; `update` must not explode."""
+    from pathlib import Path
+
+    from sts2.__main__ import _canonicalize_card_rarities
+    with patch.object(Path, "exists", lambda _self: False), \
+         patch("importlib.util.spec_from_file_location") as spec:
+        _canonicalize_card_rarities()
+        spec.assert_not_called()
+
+
+def test_rarity_canonicalization_gives_up_on_an_unloadable_script():
+    from sts2.__main__ import _canonicalize_card_rarities
+    with patch("importlib.util.spec_from_file_location", return_value=None), \
+         patch("importlib.util.module_from_spec") as from_spec:
+        _canonicalize_card_rarities()
+        from_spec.assert_not_called()
+
+
+# ── export / sync failure paths ──────────────────────────────────────────
+
+def test_cli_export_reports_a_failed_write(capsys):
+    """save_aggregate returns False for an oversized or unwritable file; the
+    command used to print success regardless."""
+    with patch.object(sys, "argv", ["sts2", "export"]), \
+         patch("sts2.saves.get_run_history", return_value=[]), \
+         patch("sts2.aggregate.compute_aggregate_stats", return_value={"run_count": 0}), \
+         patch("sts2.aggregate.save_aggregate", return_value=False), \
+         pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    assert "Could not write" in capsys.readouterr().out
+
+
+def test_cli_sync_down_reports_a_failed_persist(capsys):
+    with patch.object(sys, "argv", ["sts2", "sync-down"]), \
+         patch("sts2.sync.download_stats", return_value={"run_count": 3}), \
+         patch("sts2.aggregate.load_aggregate", return_value={}), \
+         patch("sts2.aggregate.merge_aggregate", return_value={"run_count": 3}), \
+         patch("sts2.aggregate.save_aggregate", return_value=False), \
+         pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    assert "could not be persisted" in capsys.readouterr().out
+
+
+# ── localize ─────────────────────────────────────────────────────────────
+
+def test_cli_localize_lists_available_languages(capsys):
+    with patch.object(sys, "argv", ["sts2", "localize", "--list"]), \
+         patch("sts2.localize.available_languages", return_value=["de", "ja"]):
+        main()
+    out = capsys.readouterr().out
+    assert "de, ja" in out
+
+
+def test_cli_localize_list_says_so_when_the_game_offers_nothing(capsys):
+    with patch.object(sys, "argv", ["sts2", "localize", "--list"]), \
+         patch("sts2.localize.available_languages", return_value=[]):
+        main()
+    assert "is the game installed?" in capsys.readouterr().out
+
+
+def test_cli_localize_writes_the_requested_languages(capsys, tmp_path):
+    written = []
+    for code in ("de", "ja"):
+        path = tmp_path / f"{code}.json"
+        path.write_text("x" * 2048, encoding="utf-8")
+        written.append(path)
+    with patch.object(sys, "argv", ["sts2", "localize", "--lang", "de, ja"]), \
+         patch("sts2.localize.run", return_value=written) as mock_run:
+        main()
+        mock_run.assert_called_once_with(langs=["de", "ja"])
+    out = capsys.readouterr().out
+    assert "Wrote 2 translation file(s)" in out
+    assert "de  (2 KB)" in out
+    assert "Pick a language under Settings" in out
+
+
+def test_cli_localize_without_lang_builds_every_language(tmp_path):
+    path = tmp_path / "de.json"
+    path.write_text("{}", encoding="utf-8")
+    with patch.object(sys, "argv", ["sts2", "localize"]), \
+         patch("sts2.localize.run", return_value=[path]) as mock_run:
+        main()
+        mock_run.assert_called_once_with(langs=None)
+
+
+def test_cli_localize_rejects_a_dangling_lang_flag(capsys):
+    with patch.object(sys, "argv", ["sts2", "localize", "--lang"]), \
+         pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    assert "--lang needs a value" in capsys.readouterr().out
+
+
+def test_cli_localize_reports_a_missing_game_install(capsys):
+    from sts2.localize import LocalizeError
+    with patch.object(sys, "argv", ["sts2", "localize"]), \
+         patch("sts2.localize.run",
+               side_effect=LocalizeError("No SlayTheSpire2.pck under /nowhere")), \
+         pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "Could not build translations" in out
+    assert "No SlayTheSpire2.pck" in out
+
+
+def test_cli_localize_says_so_when_nothing_was_produced(capsys):
+    with patch.object(sys, "argv", ["sts2", "localize"]), \
+         patch("sts2.localize.run", return_value=[]):
+        main()
+    assert "No translations were produced." in capsys.readouterr().out
+
+
+# ── serve: browser banner and the network-bind gate ──────────────────────
+
+def test_cli_serve_opens_the_browser_and_says_why_the_console_stays_open(capsys):
+    """The console window is a deliberate antivirus mitigation, so it has to
+    explain itself -- a bare black window reads as a crash to a player who
+    just double-clicked the icon."""
+    with patch.object(sys, "argv", ["sts2", "serve", "--browser"]), \
+         patch("sts2.__main__.threading.Timer") as timer, \
+         patch("uvicorn.run"):
+        main()
+        timer.assert_called_once()
+        assert timer.return_value.start.called
+    out = capsys.readouterr().out
+    assert "Opening your browser now" in out
+    assert "Keep this window open" in out
+
+
+def test_cli_serve_without_a_browser_tells_you_to_open_the_url(capsys):
+    with patch.object(sys, "argv", ["sts2", "serve", "--no-browser"]), \
+         patch("sts2.__main__.threading.Timer") as timer, \
+         patch("uvicorn.run"):
+        main()
+        timer.assert_not_called()
+    assert "auto-open is turned off" in capsys.readouterr().out
+
+
+def test_cli_serve_on_a_network_bind_explains_the_token(capsys):
+    with patch.object(sys, "argv", ["sts2", "serve", "--no-browser"]), \
+         patch("sts2.config.HOST", "0.0.0.0"), \
+         patch.dict("os.environ", {"STS2_AUTH_TOKEN": "s3cret"}, clear=False), \
+         patch("uvicorn.run") as mock_uvicorn:
+        main()
+        mock_uvicorn.assert_called_once()
+    out = capsys.readouterr().out
+    assert "must present STS2_AUTH_TOKEN" in out
+    assert "?token=" in out
+
+
+def test_cli_serve_warns_loudly_about_an_unauthenticated_network_bind(capsys):
+    with patch.object(sys, "argv", ["sts2", "serve", "--no-browser"]), \
+         patch("sts2.config.HOST", "0.0.0.0"), \
+         patch.dict("os.environ", {"STS2_ALLOW_UNAUTHENTICATED": "1"}, clear=False), \
+         patch("uvicorn.run") as mock_uvicorn:
+        os.environ.pop("STS2_AUTH_TOKEN", None)
+        main()
+        mock_uvicorn.assert_called_once()
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_cli_serve_refuses_an_unauthenticated_network_bind(capsys):
+    """The whole point of the gate: binding to the LAN with no credential must
+    not start the server, only explain the two ways to proceed."""
+    with patch.object(sys, "argv", ["sts2", "serve", "--no-browser"]), \
+         patch("sts2.config.HOST", "0.0.0.0"), \
+         patch("uvicorn.run") as mock_uvicorn, \
+         patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("STS2_AUTH_TOKEN", None)
+        os.environ.pop("STS2_ALLOW_UNAUTHENTICATED", None)
+        with pytest.raises(SystemExit) as exc:
+            main()
+        mock_uvicorn.assert_not_called()
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "refusing to bind" in out
+    assert "STS2_AUTH_TOKEN" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -252,8 +252,12 @@ def test_program_name_matches_a_packaged_build():
     """A packaged build has no `spirescope` on PATH, so printing that name
     tells the reader to run something they do not have."""
     from sts2.__main__ import _program_name
+    # Built with os.path.join rather than a literal Windows path: basename()
+    # only splits on the host separator, so a hardcoded backslash path is the
+    # whole string on Linux and macOS.
+    exe = os.path.join("Games", "Spirescope", "Spirescope.exe")
     with patch.object(sys, "frozen", True, create=True), \
-         patch.object(sys, "executable", r"C:\Games\Spirescope\Spirescope.exe"):
+         patch.object(sys, "executable", exe):
         assert _program_name() == "Spirescope.exe"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,466 @@
+"""Path detection and state migration.
+
+config.py resolves every directory the app touches, and it does so at import
+time from the host platform. The branches for the platforms CI does not run
+on are therefore invisible: a Windows-only checkout exercises the win32 leg
+and nothing else, so a broken macOS or Steam Deck path ships undetected.
+
+The private helpers are called directly here rather than re-importing the
+module, because the module-level constants are computed once at import and
+re-importing to observe them would leave a second copy of config in
+sys.modules for every other test to trip over.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+from sts2 import config
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Detection reads the environment first; a real STS2_* var on the dev
+    machine would mask every branch below."""
+    for var in ("STS2_DATA_DIR", "STS2_STATE_DIR", "STS2_SAVE_DIR",
+                "STS2_MODS_DIR", "STS2_GAME_DIR", "STS2_PORT",
+                "XDG_DATA_HOME", "APPDATA"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _home(monkeypatch, path):
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: path))
+
+
+# --------------------------------------------------------------- data dir
+
+def test_data_dir_honours_the_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv("STS2_DATA_DIR", str(tmp_path / "elsewhere"))
+    assert config._find_data_dir() == tmp_path / "elsewhere"
+
+
+def test_data_dir_of_a_frozen_build_sits_next_to_the_executable(monkeypatch, tmp_path):
+    """A frozen build unpacks to a temp dir that is discarded on exit, so
+    installed data updates have to live beside the exe or they vanish."""
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "app" / "Spirescope.exe"))
+    assert config._find_data_dir() == tmp_path / "app" / "data"
+
+
+def test_data_dir_of_a_source_checkout_is_the_bundled_one(monkeypatch):
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    assert config._find_data_dir() == config.BUNDLED_DATA_DIR
+
+
+def test_ensure_data_dir_does_nothing_for_a_source_checkout(monkeypatch):
+    monkeypatch.setattr(config, "DATA_DIR", config.BUNDLED_DATA_DIR)
+    config.ensure_data_dir()          # must not raise or copy anything
+
+
+def test_ensure_data_dir_seeds_an_empty_frozen_data_dir(monkeypatch, tmp_path):
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    (bundled / "cards.json").write_text("[]", encoding="utf-8")
+    target = tmp_path / "beside-exe"
+    monkeypatch.setattr(config, "BUNDLED_DATA_DIR", bundled)
+    monkeypatch.setattr(config, "DATA_DIR", target)
+    config.ensure_data_dir()
+    assert (target / "cards.json").read_text(encoding="utf-8") == "[]"
+
+
+def test_ensure_data_dir_leaves_an_already_seeded_dir_alone(monkeypatch, tmp_path):
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    (bundled / "cards.json").write_text("[]", encoding="utf-8")
+    target = tmp_path / "beside-exe"
+    target.mkdir()
+    (target / "cards.json").write_text('["installed update"]', encoding="utf-8")
+    monkeypatch.setattr(config, "BUNDLED_DATA_DIR", bundled)
+    monkeypatch.setattr(config, "DATA_DIR", target)
+    config.ensure_data_dir()
+    assert "installed update" in (target / "cards.json").read_text(encoding="utf-8")
+
+
+def test_ensure_data_dir_survives_an_unwritable_target(monkeypatch, tmp_path, caplog):
+    """Knowledge loading tolerates missing files, so a failed seed must log
+    and continue rather than take the whole app down at startup."""
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    monkeypatch.setattr(config, "BUNDLED_DATA_DIR", bundled)
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path / "target")
+
+    def boom(*_a, **_kw):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr("shutil.copytree", boom)
+    config.ensure_data_dir()
+    assert "Failed to seed data dir" in caplog.text
+
+
+# -------------------------------------------------------------- state dir
+
+def test_state_dir_honours_the_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv("STS2_STATE_DIR", str(tmp_path / "state"))
+    assert config._find_state_dir() == tmp_path / "state"
+
+
+@pytest.mark.parametrize("platform, expected_parts", [
+    ("win32", ("Roaming", "SpireScope")),
+    ("darwin", ("Library", "Application Support", "SpireScope")),
+    ("linux", (".local", "share", "SpireScope")),
+])
+def test_state_dir_follows_each_platform_convention(
+        monkeypatch, tmp_path, platform, expected_parts):
+    monkeypatch.setattr(sys, "platform", platform)
+    _home(monkeypatch, tmp_path)
+    result = config._find_state_dir()
+    assert result.parts[-len(expected_parts):] == expected_parts
+
+
+def test_state_dir_on_windows_prefers_appdata(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("APPDATA", str(tmp_path / "AppData" / "Roaming"))
+    assert config._find_state_dir() == tmp_path / "AppData" / "Roaming" / "SpireScope"
+
+
+def test_state_dir_on_linux_prefers_xdg_data_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    assert config._find_state_dir() == tmp_path / "xdg" / "SpireScope"
+
+
+def test_state_path_creates_the_directory_on_demand(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path / "fresh")
+    path = config.state_path("settings.json")
+    assert path.parent.is_dir()
+    assert path.name == "settings.json"
+
+
+def test_state_path_still_returns_a_path_when_the_directory_cannot_be_made(
+        monkeypatch, tmp_path, caplog):
+    """Callers write through persist.py, which handles its own errors. Raising
+    here would break startup on a read-only home directory instead."""
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path / "nope")
+
+    def boom(*_a, **_kw):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+    assert config.state_path("settings.json").name == "settings.json"
+    assert "Could not create state directory" in caplog.text
+
+
+# --------------------------------------------------------------- migration
+
+def test_migration_moves_pre_303_state_out_of_the_data_dir(monkeypatch, tmp_path):
+    data, state = tmp_path / "data", tmp_path / "state"
+    data.mkdir()
+    (data / "settings.json").write_text("{}", encoding="utf-8")
+    (data / "hypotheses.json").write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(config, "DATA_DIR", data)
+    monkeypatch.setattr(config, "STATE_DIR", state)
+    moved = config.migrate_state_from_data_dir()
+    assert sorted(moved) == ["hypotheses.json", "settings.json"]
+    assert (state / "settings.json").exists()
+    assert not (data / "settings.json").exists()
+
+
+def test_migration_never_overwrites_state_already_in_the_new_location(
+        monkeypatch, tmp_path):
+    """The new copy is the live one. Clobbering it with a stale pre-3.0.3 file
+    would silently roll the user's settings back."""
+    data, state = tmp_path / "data", tmp_path / "state"
+    data.mkdir()
+    state.mkdir()
+    (data / "settings.json").write_text('{"old": true}', encoding="utf-8")
+    (state / "settings.json").write_text('{"current": true}', encoding="utf-8")
+    monkeypatch.setattr(config, "DATA_DIR", data)
+    monkeypatch.setattr(config, "STATE_DIR", state)
+    assert config.migrate_state_from_data_dir() == []
+    assert "current" in (state / "settings.json").read_text(encoding="utf-8")
+
+
+def test_migration_also_checks_beside_a_frozen_executable(monkeypatch, tmp_path):
+    data, state, exe_dir = tmp_path / "data", tmp_path / "state", tmp_path / "exe"
+    data.mkdir()
+    exe_dir.mkdir()
+    (exe_dir / "community_aggregate.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(config, "DATA_DIR", data)
+    monkeypatch.setattr(config, "STATE_DIR", state)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(exe_dir / "Spirescope.exe"))
+    assert config.migrate_state_from_data_dir() == ["community_aggregate.json"]
+    assert (state / "community_aggregate.json").exists()
+
+
+def test_migration_moves_user_mods_but_never_the_shipped_readme(
+        monkeypatch, tmp_path):
+    """mods/ is not purely user state -- the package ships a README in it, and
+    moving that out of a source checkout deletes a tracked file."""
+    data, state = tmp_path / "data", tmp_path / "state"
+    mods = data / "mods"
+    mods.mkdir(parents=True)
+    (mods / "README.md").write_text("format docs", encoding="utf-8")
+    (mods / "my_mod.json").write_text("{}", encoding="utf-8")
+    (mods / "subdir").mkdir()
+    monkeypatch.setattr(config, "DATA_DIR", data)
+    monkeypatch.setattr(config, "STATE_DIR", state)
+    assert config.migrate_state_from_data_dir() == ["mods/my_mod.json"]
+    assert (mods / "README.md").exists()
+    assert (state / "mods" / "my_mod.json").exists()
+
+
+def test_migration_skips_a_mod_that_already_exists_in_the_new_location(
+        monkeypatch, tmp_path):
+    data, state = tmp_path / "data", tmp_path / "state"
+    (data / "mods").mkdir(parents=True)
+    (data / "mods" / "my_mod.json").write_text('{"old": 1}', encoding="utf-8")
+    (state / "mods").mkdir(parents=True)
+    (state / "mods" / "my_mod.json").write_text('{"new": 1}', encoding="utf-8")
+    monkeypatch.setattr(config, "DATA_DIR", data)
+    monkeypatch.setattr(config, "STATE_DIR", state)
+    assert config.migrate_state_from_data_dir() == []
+    assert "new" in (state / "mods" / "my_mod.json").read_text(encoding="utf-8")
+
+
+def test_migration_reports_nothing_when_there_is_nothing_to_move(
+        monkeypatch, tmp_path):
+    data, state = tmp_path / "data", tmp_path / "state"
+    data.mkdir()
+    monkeypatch.setattr(config, "DATA_DIR", data)
+    monkeypatch.setattr(config, "STATE_DIR", state)
+    assert config.migrate_state_from_data_dir() == []
+
+
+@pytest.mark.parametrize("victim", ["settings.json", "mods/my_mod.json"])
+def test_migration_logs_and_continues_when_a_move_fails(
+        monkeypatch, tmp_path, caplog, victim):
+    data, state = tmp_path / "data", tmp_path / "state"
+    (data / "mods").mkdir(parents=True)
+    (data / "settings.json").write_text("{}", encoding="utf-8")
+    (data / "mods" / "my_mod.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(config, "DATA_DIR", data)
+    monkeypatch.setattr(config, "STATE_DIR", state)
+
+    def boom(*_a, **_kw):
+        raise OSError("file in use")
+
+    monkeypatch.setattr("shutil.move", boom)
+    assert config.migrate_state_from_data_dir() == []
+    assert "Could not migrate" in caplog.text
+
+
+# --------------------------------------------------------------- save dirs
+
+def test_save_dirs_env_override_accepts_a_list(monkeypatch, tmp_path):
+    a, b = tmp_path / "a", tmp_path / "b"
+    import os
+    monkeypatch.setenv("STS2_SAVE_DIR", f"{a}{os.pathsep}{b}")
+    assert config._find_save_dirs() == [a, b]
+
+
+def test_save_dirs_env_override_ignores_empty_entries(monkeypatch, tmp_path):
+    import os
+    monkeypatch.setenv("STS2_SAVE_DIR", f"{tmp_path}{os.pathsep}{os.pathsep}")
+    assert config._find_save_dirs() == [tmp_path]
+
+
+def test_save_dirs_returns_a_plausible_path_when_the_game_never_ran(
+        monkeypatch, tmp_path):
+    """Returning a path that does not exist yet lets the UI name the directory
+    it is watching instead of showing an empty string."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    _home(monkeypatch, tmp_path)
+    result = config._find_save_dirs()
+    assert result == [tmp_path / "Library" / "Application Support"
+                      / "SlayTheSpire2" / "saves"]
+
+
+def test_save_dirs_falls_back_when_the_steam_tree_holds_no_profiles(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    _home(monkeypatch, tmp_path)
+    sts2 = tmp_path / "Library" / "Application Support" / "SlayTheSpire2"
+    (sts2 / "steam" / "76561198000000000").mkdir(parents=True)
+    (sts2 / "steam" / "not-a-dir.txt").write_text("x", encoding="utf-8")
+    assert config._find_save_dirs() == [sts2 / "saves"]
+
+
+def _make_profile(root, steam_id, profile, modded=False, run_mtime=None):
+    parts = [root, "steam", steam_id] + (["modded"] if modded else []) + [profile]
+    saves = Path(*[str(p) for p in parts]) / "saves"
+    history = saves / "history"
+    history.mkdir(parents=True)
+    if run_mtime is not None:
+        run = history / "1000.run"
+        run.write_text("{}", encoding="utf-8")
+        import os
+        os.utime(run, (run_mtime, run_mtime))
+    return saves
+
+
+def test_save_dirs_groups_vanilla_and_modded_trees_freshest_first(
+        monkeypatch, tmp_path):
+    """Since game v0.108.0 a first modded launch copies vanilla saves across,
+    so history lives in both trees and both must be returned."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    _home(monkeypatch, tmp_path)
+    sts2 = tmp_path / "Library" / "Application Support" / "SlayTheSpire2"
+    vanilla = _make_profile(sts2, "7656119", "profile1", run_mtime=1_000)
+    modded = _make_profile(sts2, "7656119", "profile1", modded=True, run_mtime=9_000)
+    assert config._find_save_dirs() == [modded, vanilla]
+
+
+def test_save_dirs_picks_the_profile_with_the_freshest_run(monkeypatch, tmp_path):
+    """Other profiles are other players; merging their runs would conflate
+    two people's statistics."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    _home(monkeypatch, tmp_path)
+    sts2 = tmp_path / "Library" / "Application Support" / "SlayTheSpire2"
+    _make_profile(sts2, "7656119", "profile1", run_mtime=1_000)
+    active = _make_profile(sts2, "7656119", "profile2", run_mtime=9_000)
+    assert config._find_save_dirs() == [active]
+
+
+def test_save_dirs_ignores_directories_that_are_not_profiles(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    _home(monkeypatch, tmp_path)
+    sts2 = tmp_path / "Library" / "Application Support" / "SlayTheSpire2"
+    real = _make_profile(sts2, "7656119", "profile1", run_mtime=1_000)
+    (sts2 / "steam" / "7656119" / "screenshots").mkdir(parents=True, exist_ok=True)
+    (sts2 / "steam" / "7656119" / "profile_no_saves").mkdir(parents=True)
+    assert config._find_save_dirs() == [real]
+
+
+def test_save_dirs_finds_the_steam_deck_proton_prefix(monkeypatch, tmp_path):
+    """On a Steam Deck the saves are inside the Proton prefix, not in the
+    native XDG location -- missing this makes the app look empty on Deck."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    _home(monkeypatch, tmp_path)
+    proton = (tmp_path / ".local" / "share" / "Steam" / "steamapps" / "compatdata"
+              / "2868840" / "pfx" / "drive_c" / "users" / "steamuser"
+              / "AppData" / "Local" / "SlayTheSpire2")
+    saves = _make_profile(proton, "7656119", "profile1", run_mtime=5_000)
+    assert config._find_save_dirs() == [saves]
+
+
+def test_find_save_dir_returns_the_freshest_of_the_group(monkeypatch, tmp_path):
+    import os
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    monkeypatch.setenv("STS2_SAVE_DIR", f"{a}{os.pathsep}{b}")
+    assert config._find_save_dir() == a
+
+
+# --------------------------------------------------------------- freshness
+
+def test_freshness_of_a_directory_without_history_is_zero(tmp_path):
+    assert config._save_dir_freshness(tmp_path) == 0.0
+
+
+def test_freshness_is_the_newest_run_file(tmp_path):
+    import os
+    history = tmp_path / "history"
+    history.mkdir()
+    for name, mtime in (("1.run", 1_000), ("2.run", 5_000), ("notes.txt", 9_000)):
+        f = history / name
+        f.write_text("{}", encoding="utf-8")
+        os.utime(f, (mtime, mtime))
+    assert config._save_dir_freshness(tmp_path) == 5_000
+
+
+def test_freshness_of_an_unreadable_history_is_zero(tmp_path, monkeypatch):
+    (tmp_path / "history").mkdir()
+
+    def boom(*_a, **_kw):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "iterdir", boom)
+    assert config._save_dir_freshness(tmp_path) == 0.0
+
+
+# ------------------------------------------------------------- steam id
+
+@pytest.mark.parametrize("parts, expected", [
+    (("SlayTheSpire2", "steam", "76561198000000000", "profile1", "saves"),
+     "76561198000000000"),
+    (("SlayTheSpire2", "steam", "modded", "profile1", "saves"), ""),
+    (("custom", "saves"), ""),
+    (("SlayTheSpire2", "steam"), ""),
+])
+def test_local_steam_id_is_read_from_the_save_path(parts, expected):
+    assert config.local_steam_id(Path(*parts)) == expected
+
+
+def test_local_steam_id_defaults_to_the_detected_save_dir(monkeypatch):
+    monkeypatch.setattr(config, "SAVE_DIR",
+                        Path("root", "steam", "76561198000000001", "profile1"))
+    assert config.local_steam_id() == "76561198000000001"
+
+
+# --------------------------------------------------------------- mods dir
+
+def test_mods_dir_honours_the_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv("STS2_MODS_DIR", str(tmp_path / "mods"))
+    assert config._find_mods_dir() == tmp_path / "mods"
+
+
+def test_mods_dir_of_a_frozen_build_sits_next_to_the_executable(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "app" / "Spirescope.exe"))
+    assert config._find_mods_dir() == tmp_path / "app" / "mods"
+
+
+def test_mods_dir_of_a_source_checkout_lives_with_user_state(monkeypatch, tmp_path):
+    """Not in the data dir: `sts2 update` replaces that wholesale and would
+    take the user's mods with it."""
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path / "state")
+    assert config._find_mods_dir() == tmp_path / "state" / "mods"
+
+
+# --------------------------------------------------------------- game dir
+
+def test_game_dir_honours_the_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv("STS2_GAME_DIR", str(tmp_path / "game"))
+    assert config._find_game_dir() == tmp_path / "game"
+
+
+def test_game_dir_falls_back_to_the_working_directory(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(Path, "exists", lambda _self: False)
+    assert config._find_game_dir() == Path(".")
+
+
+def test_game_dir_scans_every_drive_letter_on_windows(monkeypatch):
+    """A Steam library on D: or E: is the common case on Windows, and only
+    the win32 leg looks past C:."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    target = Path(r"E:\SteamLibrary\steamapps\common\Slay the Spire 2")
+    monkeypatch.setattr(Path, "exists", lambda self: self == target)
+    assert config._find_game_dir() == target
+
+
+# ------------------------------------------------------------------- port
+
+@pytest.mark.parametrize("raw, expected", [
+    ("9000", 9000),
+    ("1", 1),
+    ("65535", 65535),
+    ("not-a-number", 8000),     # unparseable falls back
+    ("", 8000),
+    ("0", 8000),                # out of range falls back
+    ("65536", 8000),
+    ("-1", 8000),
+])
+def test_port_parsing_rejects_anything_outside_the_valid_range(
+        monkeypatch, raw, expected):
+    monkeypatch.setenv("STS2_PORT", raw)
+    assert config._parse_port() == expected
+
+
+def test_port_defaults_when_unset(monkeypatch):
+    monkeypatch.delenv("STS2_PORT", raising=False)
+    assert config._parse_port() == 8000

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -438,6 +438,8 @@ def test_game_dir_scans_every_drive_letter_on_windows(monkeypatch):
     """A Steam library on D: or E: is the common case on Windows, and only
     the win32 leg looks past C:."""
     monkeypatch.setattr(sys, "platform", "win32")
+    # Safe off Windows: _find_game_dir builds this same literal, so the two
+    # Paths compare equal however the host platform parses the separators.
     target = Path(r"E:\SteamLibrary\steamapps\common\Slay the Spire 2")
     monkeypatch.setattr(Path, "exists", lambda self: self == target)
     assert config._find_game_dir() == target

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -2,8 +2,11 @@
 import hashlib
 import json
 import tarfile
+import urllib.error
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from sts2 import updater
 from sts2.sources import (
@@ -108,6 +111,99 @@ def test_wikigg_relics_convert_icon_runs():
         relics = src.fetch_relics()
     assert relics[0]["description"] == (
         "Gain 1 Energy at the start of each turn. You can no longer obtain potions.")
+
+
+def test_regent_module_is_normalised_to_the_app_spelling():
+    """The wiki names the character "The Regent"; config.py, logparser.py and
+    every template use "Regent". A leak here splits one character into two
+    across the whole app."""
+    lua = '''
+    local d = {
+      ["Royal Decree"] = {
+        Cost = 1, Color = "The Regent", Type = "Skill",
+        Rarity = "Common", Text = "Do a thing."
+      }
+    }
+    '''
+    src = WikiggSource()
+    with patch.object(WikiggSource, "_fetch_modules",
+                      return_value={"Module:Cards/StS2 data/Regent": lua}):
+        cards = src.fetch_cards()
+    assert [c["character"] for c in cards] == ["Regent"]
+
+
+def test_character_falls_back_to_the_module_title():
+    """A module entry with no Color field still belongs to the character whose
+    page it came from."""
+    lua = '["Nameless"] = { Cost = 1, Type = "Skill", Text = "x" }'
+    src = WikiggSource()
+    with patch.object(WikiggSource, "_fetch_modules",
+                      return_value={"Module:Cards/StS2 data/Defect": lua}):
+        cards = src.fetch_cards()
+    assert cards[0]["character"] == "Defect"
+
+
+class TestWikiggFetchModules:
+    """The MediaWiki API call itself: batching, the response cap, and the
+    shape-tolerance that keeps one odd page from aborting a whole scrape.
+    """
+
+    @staticmethod
+    def _response(payload):
+        from unittest.mock import MagicMock
+        resp = MagicMock()
+        resp.read.return_value = json.dumps(payload).encode("utf-8")
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def _page(self, title, content):
+        return {"title": title,
+                "revisions": [{"slots": {"main": {"content": content}}}]}
+
+    def test_titles_are_requested_in_batches_of_three(self):
+        """Six modules in one request would be a single oversized response and
+        a heavier hit on the wiki; the delay between batches is the politeness
+        the scrape depends on."""
+        titles = [f"Module:{i}" for i in range(7)]
+        responses = [
+            self._response({"query": {"pages": [
+                self._page(t, f"content {t}") for t in titles[i:i + 3]]}})
+            for i in range(0, 7, 3)
+        ]
+        with patch("sts2.sources.urllib.request.urlopen", side_effect=responses) \
+                as urlopen, patch("sts2.sources.time.sleep") as sleep:
+            got = WikiggSource()._fetch_modules(titles)
+        assert urlopen.call_count == 3
+        assert sleep.call_count == 2          # between batches, not before the first
+        assert len(got) == 7
+        assert got["Module:0"] == "content Module:0"
+
+    def test_an_oversized_response_is_refused(self):
+        from unittest.mock import MagicMock
+        resp = MagicMock()
+        resp.read.return_value = b"x" * 11
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("sts2.sources._MAX_RESPONSE_SIZE", 10), \
+             patch("sts2.sources.urllib.request.urlopen", return_value=resp), \
+             pytest.raises(urllib.error.URLError, match="too large"):
+            WikiggSource()._fetch_modules(["Module:X"])
+
+    def test_a_page_with_no_revisions_is_skipped_not_fatal(self):
+        payload = {"query": {"pages": [
+            {"title": "Module:Missing"},
+            self._page("Module:Real", "content"),
+        ]}}
+        with patch("sts2.sources.urllib.request.urlopen",
+                   return_value=self._response(payload)):
+            got = WikiggSource()._fetch_modules(["Module:Missing", "Module:Real"])
+        assert got == {"Module:Real": "content"}
+
+    def test_an_empty_query_result_yields_nothing(self):
+        with patch("sts2.sources.urllib.request.urlopen",
+                   return_value=self._response({})):
+            assert WikiggSource()._fetch_modules(["Module:X"]) == {}
 
 
 def test_icon_runs_cover_the_tokens_the_wiki_actually_emits():

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -493,3 +493,157 @@ class TestFetchPage:
              patch("sts2.fetcher.urllib.request.urlopen", return_value=mock_resp):
             with pytest.raises(urllib.error.URLError, match="too large"):
                 _fetch_page("/cards")
+
+    def test_a_response_under_the_cap_is_decoded(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = "<html>Café</html>".encode("utf-8")
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("sts2.fetcher.urllib.request.urlopen", return_value=mock_resp):
+            assert _fetch_page("/cards") == "<html>Café</html>"
+
+    def test_the_user_agent_identifies_the_project(self):
+        from sts2.config import VERSION
+        from sts2.fetcher import _get_user_agent
+        agent = _get_user_agent()
+        assert VERSION in agent
+        assert "github.com/thequantumfalcon/spirescope" in agent
+
+
+# ── Extraction fallbacks ─────────────────────────────────────────────────
+#
+# _extract_json_objects tries four strategies in order and only falls through
+# when the previous one found nothing. Strategy 1 was the only one under test,
+# so the wiki could switch to any of the other three shapes and the scrape
+# would silently return zero items -- which the "no X found" guard then reads
+# as "keep the existing data", leaving stale text in place with no error.
+
+CARD_OBJ = {"category": "CARD", "id": "bash-ironclad", "name": "Bash",
+            "cardType": "Attack", "description": "Deal 8 damage."}
+
+
+def _push(payload: str) -> str:
+    """One Next.js RSC streaming chunk as it appears in the page source."""
+    return f'self.__next_f.push([1,"{payload}"])'
+
+
+def _u22(obj: dict) -> str:
+    """Serialise with quotes as \\u0022 escapes, which is how the site's RSC
+    payloads carry them."""
+    return json.dumps(obj).replace('"', '\\u0022')
+
+
+class TestExtractionStrategyFallbacks:
+    def test_strategy_2_reads_an_object_that_contains_a_nested_one(self):
+        """The flat pattern cannot cross a '{', so an object that gained a
+        nested field would vanish entirely."""
+        html = '{"meta":{"a":1},"category":"CARD","id":"nested-1","name":"N"}'
+        assert [o["id"] for o in _extract_json_objects(html, "CARD")] == ["nested-1"]
+
+    def test_strategy_3_walks_the_next_data_script_tag(self):
+        deep = {"props": {"pageProps": {"items": [
+            dict(CARD_OBJ, id="deep-1", meta={"x": {"y": 1}})]}}}
+        html = ('<script id="__NEXT_DATA__" type="application/json">'
+                f'{json.dumps(deep)}</script>')
+        assert [o["id"] for o in _extract_json_objects(html, "CARD")] == ["deep-1"]
+
+    def test_a_malformed_next_data_block_is_ignored_not_fatal(self):
+        html = '<script id="__NEXT_DATA__">{not json at all</script>'
+        assert _extract_json_objects(html, "CARD") == []
+
+    def test_strategy_4_reads_an_rsc_streaming_payload(self):
+        assert [o["id"] for o in
+                _extract_json_objects(_push(_u22(CARD_OBJ)), "CARD")] == [
+            "bash-ironclad"]
+
+    def test_strategy_4_rejoins_an_object_split_across_push_calls(self):
+        """The site splits JSON mid-token across push() calls, so the chunks
+        must be concatenated before decoding -- an escape sequence can straddle
+        a chunk boundary."""
+        payload = _u22(CARD_OBJ)
+        half = len(payload) // 2
+        html = _push(payload[:half]) + _push(payload[half:])
+        assert [o["id"] for o in _extract_json_objects(html, "CARD")] == [
+            "bash-ironclad"]
+
+    def test_strategy_4_finds_objects_whose_own_text_contains_braces(self):
+        """Card text carries {token} markup, which is invisible to the flat
+        pattern -- the bracket-balanced second pass is what catches it."""
+        obj = dict(CARD_OBJ, id="braced", meta={"deep": {"deeper": 1}})
+        assert [o["id"] for o in _extract_json_objects(_push(_u22(obj)), "CARD")] == [
+            "braced"]
+
+    def test_rsc_extraction_on_a_page_with_no_push_calls_is_a_no_op(self):
+        from sts2.fetcher import _extract_from_rsc_payloads
+        results, seen = [], set()
+        _extract_from_rsc_payloads("<html>no payloads here</html>", "CARD",
+                                   results, seen)
+        assert results == []
+
+    def test_every_strategy_failing_returns_empty_and_says_so(self, caplog):
+        assert _extract_json_objects("<html>nothing useful</html>", "CARD") == []
+        assert "All extraction strategies found 0" in caplog.text
+
+    def test_the_same_id_is_never_returned_twice_across_strategies(self):
+        html = _push(_u22(CARD_OBJ)) + _push(_u22(CARD_OBJ))
+        assert len(_extract_json_objects(html, "CARD")) == 1
+
+
+class TestWalkJsonForCategory:
+    def test_finds_a_match_at_any_depth(self):
+        from sts2.fetcher import _walk_json_for_category
+        results, seen = [], set()
+        _walk_json_for_category(
+            {"a": {"b": [{"c": dict(CARD_OBJ, id="found")}]}},
+            "CARD", results, seen)
+        assert [o["id"] for o in results] == ["found"]
+
+    def test_ignores_a_structure_with_no_matching_category(self):
+        from sts2.fetcher import _walk_json_for_category
+        results, seen = [], set()
+        _walk_json_for_category({"a": {"b": 1}}, "RELIC", results, seen)
+        assert results == []
+
+    def test_gives_up_before_recursing_forever(self):
+        """A cyclic or pathologically deep payload must not blow the stack."""
+        from sts2.fetcher import _walk_json_for_category
+        root = cursor = {}
+        for _ in range(30):
+            cursor["next"] = {}
+            cursor = cursor["next"]
+        cursor.update(dict(CARD_OBJ, id="too-deep"))
+        results, seen = [], set()
+        _walk_json_for_category(root, "CARD", results, seen)
+        assert results == []
+
+    def test_an_object_without_an_id_is_skipped(self):
+        from sts2.fetcher import _walk_json_for_category
+        results, seen = [], set()
+        _walk_json_for_category({"category": "CARD", "name": "No Id"},
+                                "CARD", results, seen)
+        assert results == []
+
+
+class TestDecodeUnicodeEscapes:
+    """A previous fix ran the payload through unicode_escape, which round-trips
+    UTF-8 through latin-1 and mangled every real non-ASCII character: three
+    relic descriptions shipped reading 'Cards containing â€œStrike'.
+    The data file was repaired but the function was not, so the next refresh
+    reproduced it exactly.
+    """
+
+    def test_resolves_a_lone_escape(self):
+        from sts2.fetcher import _decode_unicode_escapes
+        assert _decode_unicode_escapes(r"“Strike”") == "“Strike”"
+
+    def test_recombines_a_surrogate_pair_into_one_character(self):
+        from sts2.fetcher import _decode_unicode_escapes
+        assert _decode_unicode_escapes(r"😀") == "\U0001F600"
+
+    def test_leaves_literal_non_ascii_text_untouched(self):
+        from sts2.fetcher import _decode_unicode_escapes
+        assert _decode_unicode_escapes("Café “x”") == "Café “x”"
+
+    def test_mixes_escaped_and_literal_text(self):
+        from sts2.fetcher import _decode_unicode_escapes
+        assert _decode_unicode_escapes(r"Café déjà") == "Café déjà"

--- a/tests/test_graveyard.py
+++ b/tests/test_graveyard.py
@@ -1,0 +1,227 @@
+"""Procedural epitaphs for dead runs.
+
+The epitaph is the only place in the app that narrates a run back to the
+player, and it is generated from facts rather than written by hand -- so a
+fact that stops being detected does not throw, it just quietly produces a
+blander line. Each fact below is tested for the text it unlocks.
+
+Determinism matters as much as the wording: the same run must always get the
+same epitaph, or the graveyard page reshuffles itself on every reload.
+"""
+import pytest
+
+from sts2.graveyard import (
+    _collect_facts,
+    _fallback_epitaph,
+    _get_templates,
+    generate_epitaph,
+)
+from sts2.models import RunFloor, RunHistory
+
+
+def _floor(n, ftype="monster", dmg=0, gold=0, gained=(), used=()):
+    return RunFloor(floor=n, type=ftype, damage_taken=dmg, gold=gold,
+                    potions_gained=list(gained), potions_used=list(used))
+
+
+def _run(rid="run-1", win=False, deck=None, floors=None, run_time=1200,
+         killed_by="", character="Ironclad"):
+    return RunHistory(id=rid, character=character, win=win, run_time=run_time,
+                      killed_by=killed_by, deck=deck or ["CARD.X"] * 20,
+                      floors=floors if floors is not None else [_floor(20)])
+
+
+class _StubKB:
+    def __init__(self, types):
+        self._types = types
+
+    def get_card_by_id(self, cid):
+        kind = self._types.get(cid)
+        return None if kind is None else type("Card", (), {"type": kind})()
+
+
+# ------------------------------------------------------------------- contract
+
+def test_a_won_run_has_no_epitaph():
+    assert generate_epitaph(_run(win=True)) == ""
+
+
+def test_the_epitaph_is_stable_for_the_same_run():
+    run = _run(rid="stable-run")
+    assert generate_epitaph(run) == generate_epitaph(run)
+
+
+def test_the_epitaph_depends_on_the_run_id():
+    """Selection is seeded from the id, so two runs with identical facts still
+    get different lines -- otherwise a bad session reads as one repeated joke."""
+    facts_only = dict(floors=[_floor(20)], deck=["CARD.X"] * 20)
+    lines = {generate_epitaph(_run(rid=f"run-{i}", **facts_only))
+             for i in range(12)}
+    assert len(lines) > 1
+
+
+def test_an_unremarkable_run_still_gets_an_epitaph():
+    plain = _run(rid="plain", floors=[_floor(20)], deck=["CARD.X"] * 20)
+    assert _collect_facts(plain, None) == {}
+    assert generate_epitaph(plain)
+
+
+# ---------------------------------------------------------------------- facts
+
+def test_potion_hoarding_is_noticed():
+    run = _run(floors=[_floor(1, gained=("A", "B")), _floor(2, gained=("C",))])
+    assert _collect_facts(run, None)["potion_hoarder"] == 3
+
+
+def test_using_a_single_potion_makes_you_a_miser_not_a_hoarder():
+    run = _run(floors=[_floor(1, gained=("A", "B", "C", "D"), used=("A",))])
+    facts = _collect_facts(run, None)
+    assert facts["potion_miser"] == (4, 1)
+    assert "potion_hoarder" not in facts
+
+
+def test_spending_potions_earns_no_potion_fact():
+    run = _run(floors=[_floor(1, gained=("A", "B", "C"), used=("A", "B"))])
+    facts = _collect_facts(run, None)
+    assert "potion_hoarder" not in facts and "potion_miser" not in facts
+
+
+def test_a_bloated_deck_is_noticed():
+    assert _collect_facts(_run(deck=["CARD.X"] * 45), None)["bloated_deck"] == 45
+
+
+def test_a_tiny_deck_only_counts_if_the_run_got_somewhere():
+    deep = _run(deck=["CARD.X"] * 10, floors=[_floor(20)])
+    shallow = _run(deck=["CARD.X"] * 10, floors=[_floor(8)])
+    assert _collect_facts(deep, None)["tiny_deck"] == 10
+    assert "tiny_deck" not in _collect_facts(shallow, None)
+
+
+def test_never_removing_starters_is_noticed_only_deep_into_a_run():
+    deck = ["CARD.STRIKE_IRONCLAD"] * 5 + ["CARD.DEFEND_IRONCLAD"] * 4
+    deep = _run(deck=deck, floors=[_floor(20)])
+    shallow = _run(deck=deck, floors=[_floor(12)])
+    assert _collect_facts(deep, None)["never_removed_starters"] == 9
+    assert "never_removed_starters" not in _collect_facts(shallow, None)
+
+
+def test_dying_on_floor_five_or_below_is_an_instant_death():
+    assert _collect_facts(_run(floors=[_floor(5)]), None)["instant_death"] == 5
+    assert "instant_death" not in _collect_facts(_run(floors=[_floor(6)]), None)
+
+
+def test_a_run_with_no_floors_counts_as_an_instant_death():
+    assert _collect_facts(_run(floors=[]), None)["instant_death"] == 0
+
+
+def test_a_boss_death_names_the_boss():
+    run = _run(floors=[_floor(16, ftype="boss")],
+               killed_by="ENCOUNTER.THE_GUARDIAN")
+    assert _collect_facts(run, None)["boss_death"] == "The Guardian"
+
+
+def test_a_boss_death_without_a_recorded_killer_stays_generic():
+    run = _run(floors=[_floor(16, ftype="boss")])
+    assert _collect_facts(run, None)["boss_death"] == "the boss"
+
+
+def test_a_long_run_is_a_marathon_measured_in_minutes():
+    assert _collect_facts(_run(run_time=7200), None)["marathon"] == 120
+    assert "marathon" not in _collect_facts(_run(run_time=600), None)
+
+
+def test_a_fast_run_that_got_far_is_a_speedrun_death():
+    fast_deep = _run(run_time=240, floors=[_floor(15)])
+    fast_shallow = _run(run_time=240, floors=[_floor(4)])
+    assert _collect_facts(fast_deep, None)["speedrun_death"] == 4
+    assert "speedrun_death" not in _collect_facts(fast_shallow, None)
+
+
+def test_heavy_damage_on_the_final_floor_is_an_overkill():
+    assert _collect_facts(_run(floors=[_floor(20, dmg=80)]), None)["overkill"] == 80
+    assert "overkill" not in _collect_facts(_run(floors=[_floor(20, dmg=10)]), None)
+
+
+def test_dying_with_a_full_purse_is_noticed():
+    assert _collect_facts(_run(floors=[_floor(20, gold=500)]), None)["died_rich"] == 500
+    assert "died_rich" not in _collect_facts(_run(floors=[_floor(20, gold=50)]), None)
+
+
+def test_getting_deep_into_the_spire_is_noticed():
+    assert _collect_facts(_run(floors=[_floor(45)]), None)["so_close"] == 45
+    assert "so_close" not in _collect_facts(_run(floors=[_floor(30)]), None)
+
+
+def test_an_all_attack_deck_needs_the_knowledge_base():
+    deck = ["CARD.A"] * 15 + ["CARD.D"] * 3
+    kb = _StubKB({"CARD.A": "Attack", "CARD.D": "Skill"})
+    assert _collect_facts(_run(deck=deck), kb)["all_attacks"] == 15
+    # without a knowledge base no card type is known, so nothing is claimed
+    assert "all_attacks" not in _collect_facts(_run(deck=deck), None)
+
+
+def test_a_balanced_deck_is_not_called_all_attacks():
+    deck = ["CARD.A"] * 10 + ["CARD.D"] * 10
+    kb = _StubKB({"CARD.A": "Attack", "CARD.D": "Skill"})
+    assert "all_attacks" not in _collect_facts(_run(deck=deck), kb)
+
+
+def test_a_short_deck_skips_the_attack_check_entirely():
+    kb = _StubKB({"CARD.A": "Attack"})
+    assert "all_attacks" not in _collect_facts(_run(deck=["CARD.A"] * 8), kb)
+
+
+# ------------------------------------------------------------------ templates
+
+@pytest.mark.parametrize("facts, needle", [
+    ({"potion_hoarder": 4}, "4 potions"),
+    ({"potion_miser": (5, 1)}, "Gained 5 potions. Used 1."),
+    ({"bloated_deck": 44}, "44 cards"),
+    ({"tiny_deck": 9}, "9-card deck"),
+    ({"never_removed_starters": 8}, "8 starter cards"),
+    ({"instant_death": 3}, "Floor 3"),
+    ({"boss_death": "Hexaghost"}, "Hexaghost"),
+    ({"marathon": 95}, "95 minutes"),
+    ({"speedrun_death": 3}, "Speedran"),
+    ({"overkill": 66}, "66 damage"),
+    ({"died_rich": 350}, "350 gold"),
+    ({"so_close": 47}, "Floor 47"),
+    ({"all_attacks": 19}, "19 Attack cards"),
+])
+def test_every_fact_unlocks_a_line_that_quotes_it(facts, needle):
+    templates = _get_templates(facts)
+    assert templates, f"{facts} produced no epitaph line"
+    assert any(needle in t for t in templates)
+
+
+def test_no_facts_means_no_templates():
+    assert _get_templates({}) == []
+
+
+def test_facts_accumulate_rather_than_replace_each_other():
+    both = _get_templates({"bloated_deck": 44, "died_rich": 300})
+    assert len(both) == len(_get_templates({"bloated_deck": 44})) + len(
+        _get_templates({"died_rich": 300}))
+
+
+# ------------------------------------------------------------------- fallback
+
+def test_the_fallback_names_the_floor_and_character():
+    run = _run(rid="f1", character="Necrobinder", floors=[_floor(17)])
+    line = _fallback_epitaph(run)
+    assert "17" in line
+
+
+def test_the_fallback_handles_a_run_with_no_floors():
+    assert "0" in _fallback_epitaph(_run(rid="f2", floors=[]))
+
+
+def test_the_fallback_is_used_when_nothing_is_notable():
+    plain = _run(rid="plain-run", floors=[_floor(20)], deck=["CARD.X"] * 20)
+    assert generate_epitaph(plain) == _fallback_epitaph(plain)
+
+
+def test_the_fallback_is_stable_and_varies_by_run():
+    lines = {_fallback_epitaph(_run(rid=f"r{i}", floors=[_floor(20)]))
+             for i in range(12)}
+    assert len(lines) > 1

--- a/tests/test_localize_pipeline.py
+++ b/tests/test_localize_pipeline.py
@@ -624,6 +624,8 @@ ENG_CARDS = {
     "BASH.description": "Deal {Damage} damage. Apply {Vuln} Vulnerable.",
     "STATIC.title": "Static",
     "STATIC.description": "Exhaust.",                     # no alignment needed
+    "STATICUP.title": "Static Upgraded",
+    "STATICUP.description": "Exhaust.",                   # no alignment, has upgrade
     "NOTRANS.title": "Untranslated",
     "NOTRANS.description": "Deal {Damage} damage.",
     "RESIDUE.title": "Residue",
@@ -648,6 +650,8 @@ DEU_CARDS = {
     "BASH.description": "Verursache {Damage} Schaden. Wende {Vuln} Verwundbar an.",
     "STATIC.title": "Statisch",
     "STATIC.description": "Verbannen.",
+    "STATICUP.title": "Statisch Verbessert",
+    "STATICUP.description": "Verbannen.",
     # NOTRANS deliberately absent: not yet translated
     "RESIDUE.title": "Kaputt {Damage}",                   # unrendered markup in a name
     "RESIDUE.description": "Verursache {Damage} Schaden.",
@@ -668,6 +672,8 @@ APP_CARDS = [
     {"id": "CARD.BASH", "description": "Deal 8 damage. Apply 2 Vulnerable.",
      "description_upgraded": "Deal 10 damage. Apply 3 Vulnerable."},
     {"id": "CARD.STATIC", "description": "Exhaust."},
+    {"id": "CARD.STATICUP", "description": "Exhaust.",
+     "description_upgraded": "Innate. Exhaust."},
     {"id": "CARD.NOTRANS", "description": "Deal 5 damage."},
     {"id": "CARD.RESIDUE", "description": "Deal 5 damage."},
     {"id": "CARD.DRIFTED", "description": "Deals 6 damage to ALL enemies."},
@@ -780,6 +786,22 @@ def test_build_translates_a_template_that_needs_no_alignment(built):
     entry = built[1]["cards"]["CARD.STATIC"]
     assert entry["name"] == "Statisch"
     assert entry["description"] == "Verbannen."
+
+
+def test_build_never_invents_an_upgraded_description(built):
+    """card_detail.html renders an "Upgraded:" block whenever the field is
+    present, so supplying one that English does not have shows translated
+    players a section English readers never see -- restating the base text
+    back at them. CARD.STATIC needs no alignment and ships no upgraded
+    English, which is exactly the shape that used to slip through (6 real
+    cards: Apotheosis, Despair, Lantern Key, Sharp Edge, Wish, Reserves).
+    """
+    _report, overlay = built
+    assert "description_upgraded" not in overlay["cards"]["CARD.STATIC"]
+    # cards that *do* ship upgraded English must still get one, whether or not
+    # their template needs aligning
+    assert "description_upgraded" in overlay["cards"]["CARD.BASH"]
+    assert overlay["cards"]["CARD.STATICUP"]["description_upgraded"] == "Verbannen."
 
 
 def test_build_uses_the_single_number_fallback_when_wording_drifted(built):

--- a/tests/test_localize_pipeline.py
+++ b/tests/test_localize_pipeline.py
@@ -1,0 +1,922 @@
+"""The text pipeline behind `python -m sts2 localize`.
+
+Everything here runs on fixture strings rather than an installed game. That
+is deliberate: the alignment and rendering logic is pure text -> text, and
+the only test that drove it before (test_localize_against_real_game) skips
+wherever the game is absent -- which includes CI, so none of it was checked
+there.
+
+The failure this guards is silent for the person maintaining the app: English
+descriptions never pass through this pipeline at all. A game patch reshapes a
+template, alignment stops recovering the numbers, and every non-English player
+gets half-rendered markup or a wrong number while the suite stays green.
+
+Template shapes used below were taken from the shipped English card, relic and
+potion descriptions of game build 0.107.1, so the fixtures exercise the forms
+that actually occur (NUM and PLURAL dominate, then ENERGY, SHOW, STAR).
+"""
+import json
+
+import pytest
+
+from sts2 import localize
+
+# ---------------------------------------------------------------- normalising
+
+@pytest.mark.parametrize("raw, expected", [
+    ("[gold]5[/gold] Gold", "5 Gold"),
+    ("[color=red]Vulnerable[/color]", "Vulnerable"),
+    ("no markup at all", "no markup at all"),
+    # braces are NOT tags -- they are template syntax and must survive, which
+    # is what lets render_text's residue check spot an unrendered token
+    ("{Damage} damage", "{Damage} damage"),
+])
+def test_strip_tags_removes_colour_markup_but_never_template_braces(raw, expected):
+    assert localize.strip_tags(raw) == expected
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("  lots   of\n space  ", "lots of space"),
+    ("", ""),
+    ("\t\n", ""),
+])
+def test_norm_ws_collapses_all_whitespace(raw, expected):
+    assert localize.norm_ws(raw) == expected
+
+
+@pytest.mark.parametrize("raw, expected", [
+    # the wiki bakes star costs as repeated icon markers
+    ("@ST", "1 Star"),
+    ("@ST@ST@ST", "3 Star"),
+    ("Costs @ST@ST to play", "Costs 2 Star to play"),
+    ("@Gold", "Gold"),
+    # templates use the plural after a count, the wiki uses the singular tag
+    ("play 3 type:Attack", "play 3 Attacks"),
+    ("play 2 type:Skill", "play 2 Skills"),
+    ("a type:Attack card", "a Attack card"),
+    ("color:red text", "red text"),
+    ("line<br>break", "line break"),
+    ("line<br />break", "line break"),
+])
+def test_norm_shipped_rewrites_wiki_icon_warts_before_alignment(raw, expected):
+    """Alignment matches a template against wiki-derived English. Every wart
+    left in here becomes an alignment failure and an entity stuck in English."""
+    assert localize.norm_shipped(raw) == expected
+
+
+# ------------------------------------------------------------------- parsing
+
+@pytest.mark.parametrize("s, start, expected", [
+    ("{a}", 0, 2),
+    ("{a{b}c}tail", 0, 6),          # nested braces
+    ("{unterminated", 0, -1),
+    ("xx{a}", 2, 4),
+])
+def test_find_close_matches_the_outermost_brace(s, start, expected):
+    assert localize.find_close(s, start) == expected
+
+
+@pytest.mark.parametrize("s, expected", [
+    ("a|b|c", ["a", "b", "c"]),
+    ("single", ["single"]),
+    ("", [""]),
+    ("a||c", ["a", "", "c"]),
+    # a '|' inside a nested token belongs to that token, not to this split
+    ("a{x|y}b|c", ["a{x|y}b", "c"]),
+])
+def test_split_top_ignores_separators_inside_nested_tokens(s, expected):
+    assert localize.split_top(s) == expected
+
+
+def _tok(spec):
+    t = localize.parse_token(spec)
+    if t is None:
+        return None
+    return (t.name, t.kind, t.fixed, t.branches, t.cond)
+
+
+@pytest.mark.parametrize("spec, expected", [
+    # plain value
+    ("Damage", ("Damage", "NUM", None, None, None)),
+    ("Damage:diff()", ("Damage", "NUM", None, None, None)),
+    ("Damage:inverseDiff()", ("Damage", "NUM", None, None, None)),
+    ("Damage:percentMore()", ("Damage", "NUM", None, None, None)),
+    ("Damage:diff)", ("Damage", "NUM", None, None, None)),   # mangled by a translator
+    # bare {} inside a branch refers to the enclosing token's value
+    ("", ("", "INNER", None, None, None)),
+    (":diff()", ("", "INNER", None, None, None)),
+    # icons
+    ("singleStarIcon", ("singleStarIcon", "STAR", 1, None, None)),
+    ("Cost:energyIcons(2)", ("Cost", "ENERGY", 2, None, None)),
+    ("Cost:energyIcons()", ("Cost", "ENERGY", None, None, None)),
+    ("S:starIcons(3)", ("S", "STAR", 3, None, None)),
+    ("S:starIcons()", ("S", "STAR", None, None, None)),
+    # enchantment names resolve through a separate lookup table
+    ("EnchantmentName", ("EnchantmentName", "ENCH", None, None, None)),
+    ("Enchantment", ("Enchantment", "ENCH", None, None, None)),
+    # plurals, including the translator-mangled "diff():plural" spelling
+    ("N:plural:card|cards", ("N", "PLURAL", None, ["card", "cards"], None)),
+    ("N:diff():plural:card|cards", ("N", "PLURAL", None, ["card", "cards"], None)),
+    ("N:plural(ru):a|b|c", ("N", "PLURAL_RU", None, ["a", "b", "c"], None)),
+    ("N:diff():plural(ru):a|b|c", ("N", "PLURAL_RU", None, ["a", "b", "c"], None)),
+    # show / choose / operator-less cond all collapse to a branch choice, and a
+    # one-branch show gains an implicit empty alternative
+    ("X:show:yes|no", ("X", "SHOW", None, ["yes", "no"], None)),
+    ("X:show:yes", ("X", "SHOW", None, ["yes", ""], None)),
+    ("X:choose(a|b):p|q", ("X", "SHOW", None, ["p", "q"], None)),
+    ("V.StringValue:cond:A|B", ("V.StringValue", "SHOW", None, ["A", "B"], None)),
+    ("A:b|c", ("A", "SHOW", None, ["b", "c"], None)),
+    # comparison cond keeps its operator and threshold
+    ("N:cond:>1?many|one", ("N", "COND", None, ["many", "one"], (">", 1))),
+    ("N:cond:<=3?few|lots", ("N", "COND", None, ["few", "lots"], ("<=", 3))),
+    ("N:cond:==0?none|some", ("N", "COND", None, ["none", "some"], ("==", 0))),
+    # single-branch fallback is a translator artifact and is left unresolvable
+    ("Chaos:only", ("Chaos", "TEXT", None, ["only"], None)),
+])
+def test_parse_token_covers_every_shipped_template_form(spec, expected):
+    assert _tok(spec) == expected
+
+
+@pytest.mark.parametrize("spec", [
+    "Weird?",                # name followed by something that is not ':'
+    "X:choose(a|b)nope",     # choose(...) not followed by ':'
+])
+def test_parse_token_refuses_what_it_cannot_read(spec):
+    """Returning None makes the whole template unparseable, which drops the
+    entity back to English -- far better than guessing at its structure."""
+    assert localize.parse_token(spec) is None
+
+
+def test_parse_template_splits_literals_from_tokens():
+    elems = localize.parse_template("Gain {Block} Block and draw {N}.")
+    assert [k for k, _ in elems] == ["lit", "tok", "lit", "tok", "lit"]
+    assert [v for k, v in elems if k == "lit"] == ["Gain ", " Block and draw ", "."]
+    assert [(v.name, v.kind) for k, v in elems if k == "tok"] == [
+        ("Block", "NUM"), ("N", "NUM")]
+
+
+def test_parse_template_handles_text_with_no_tokens():
+    assert localize.parse_template("Just words.") == [("lit", "Just words.")]
+
+
+@pytest.mark.parametrize("text", [
+    "Deal {Damage damage",     # never closed
+    "Deal {Weird?} damage.",   # token body unparseable
+])
+def test_parse_template_returns_none_on_malformed_input(text):
+    assert localize.parse_template(text) is None
+
+
+# --------------------------------------------------------- English alignment
+
+def test_extract_english_recovers_a_plain_number():
+    assert localize.extract_english("Deal {Damage} damage.", "Deal 9 damage.") == (
+        {"Damage": ["9"]}, {}, {})
+
+
+def test_extract_english_tolerates_a_dropped_trailing_period():
+    """Wiki-derived text routinely loses the final period; without this the
+    entity would fail alignment for punctuation alone."""
+    assert localize.extract_english("Deal {Damage} damage.", "Deal 9 damage") == (
+        {"Damage": ["9"]}, {}, {})
+
+
+def test_extract_english_tolerates_a_stray_space_before_punctuation():
+    assert localize.extract_english("Deal {D} damage.", "Deal 9 damage .") == (
+        {"D": ["9"]}, {}, {})
+
+
+def test_extract_english_accepts_singular_where_the_template_says_attacks():
+    """lit_pattern relaxes Attack/Skill/Power plurals because the wiki writes
+    the singular where the template writes the plural."""
+    assert localize.extract_english("Play {N} Attacks.", "Play 2 Attack.") == (
+        {"N": ["2"]}, {}, {})
+
+
+def test_extract_english_reads_wiki_type_tags_through_norm_shipped():
+    got = localize.extract_english("Whenever you play {N} Attacks, gain {B} Block.",
+                                   "Whenever you play 3 type:Attack, gain 5 Block.")
+    assert got == ({"N": ["3"], "B": ["5"]}, {}, {})
+
+
+@pytest.mark.parametrize("shipped, expected_value", [
+    ("Costs 2 Energy.", "2"),
+    # the wiki bakes an icon run as a repeated "1 Energy"
+    ("Costs 1 Energy 1 Energy 1 Energy.", "3"),
+])
+def test_extract_english_collapses_energy_icon_runs(shipped, expected_value):
+    got = localize.extract_english("Costs {C:energyIcons()}.", shipped)
+    assert got == ({"C": [expected_value]}, {}, {})
+
+
+def test_extract_english_rejects_an_ambiguous_energy_run():
+    """"2 Energy 3 Energy" is neither a single value nor a run of ones, so the
+    cost cannot be recovered and the entity must stay English."""
+    assert localize.extract_english("Costs {C:energyIcons()}.",
+                                    "Costs 2 Energy 3 Energy.") is None
+
+
+def test_extract_english_reads_a_star_cost():
+    assert localize.extract_english("Spend {S:starIcons()}.", "Spend 3 Stars.") == (
+        {"S": ["3"]}, {}, {})
+
+
+def test_extract_english_reads_star_costs_written_as_icon_markers():
+    assert localize.extract_english("Spend {S:starIcons()}.", "Spend @ST@ST.") == (
+        {"S": ["2"]}, {}, {})
+
+
+def test_fixed_icons_need_no_value():
+    assert localize.extract_english("Fixed {X:energyIcons(2)} cost.",
+                                    "Fixed 2 Energy cost.") == ({}, {}, {})
+
+
+def test_extract_english_records_which_show_branch_the_english_took():
+    tpl = "{X:show:Exhaust.|Retain.}"
+    assert localize.extract_english(tpl, "Exhaust.") == ({}, {"X": [0]}, {})
+    assert localize.extract_english(tpl, "Retain.") == ({}, {"X": [1]}, {})
+
+
+def test_extract_english_infers_one_from_a_matched_singular_branch():
+    """"Draw 1 card" carries the count only in the word "card"; recording that
+    the singular branch matched is how the value 1 is recovered at all."""
+    values, branches, hints = localize.extract_english(
+        "Draw {N} {N:diff():plural:card|cards}.", "Draw 1 card.")
+    assert values["N"][0] == "1"
+    assert branches["N"] == [0]
+    assert hints == {}
+
+
+def test_extract_english_marks_a_plural_match_as_many():
+    values, branches, hints = localize.extract_english(
+        "Draw {N} {N:diff():plural:card|cards}, then discard {N}.",
+        "Draw 2 cards, then discard 2.")
+    assert values["N"] == ["2", "2"]
+    assert branches["N"] == [1]
+    assert hints["N"] == "many"
+
+
+def test_extract_english_recovers_a_cond_threshold_from_the_else_branch():
+    """The ">1" else-branch can only have been taken when the value is 1, so
+    the number is recoverable even though it never appears in the text."""
+    values, branches, hints = localize.extract_english(
+        "Deal {D} damage {N:cond:>1?{} times|once}.", "Deal 5 damage once.")
+    assert values == {"D": ["5"], "N": ["1"]}
+    assert branches["N"] == [1]
+    assert hints == {}
+
+
+def test_extract_english_reads_a_value_from_inside_a_cond_branch():
+    values, branches, hints = localize.extract_english(
+        "Deal {D} damage {N:cond:>1?{} times|once}.", "Deal 5 damage 3 times.")
+    assert values == {"D": ["5"], "N": ["3"]}
+    assert hints["N"] == "many"
+
+
+def test_extract_english_captures_an_enchantment_name():
+    got = localize.extract_english("Enchant with {EnchantmentName}.",
+                                   "Enchant with Tezcatara's Ember.")
+    assert got == ({"EnchantmentName": ["Tezcatara's Ember"]}, {}, {})
+
+
+def test_extract_english_on_a_template_with_no_tokens_yields_nothing_to_fill():
+    assert localize.extract_english("Exhaust.", "Exhaust.") == ({}, {}, {})
+
+
+@pytest.mark.parametrize("template, shipped", [
+    # wording simply does not correspond
+    ("Deal {Damage} damage.", "Heal 9 health."),
+    # unparseable template
+    ("Deal {Damage damage.", "Deal 9 damage."),
+    # a TEXT token has no pattern, so the whole alignment is abandoned
+    ("Gain {Chaos:only} Block.", "Gain 5 Block."),
+    # unparseable body nested inside a branch
+    ("{X:show:{Weird?}|B} thing.", "B thing."),
+])
+def test_extract_english_fails_closed(template, shipped):
+    """Every failure here means "leave this entity in English". Guessing would
+    ship a wrong number to every translated player."""
+    assert localize.extract_english(template, shipped) is None
+
+
+def test_extract_english_rejects_a_degenerate_all_empty_match():
+    """A template of nothing but optional branches can match the empty string
+    anywhere; accepting that would "translate" an entity into blank text."""
+    assert localize.extract_english("{X:show:|}", "anything at all") is None
+
+
+# ------------------------------------------------------- single-number fallback
+
+def test_fallback_recovers_the_number_when_only_the_wording_drifted():
+    assert localize.fallback_single_number("Deal {Damage} damage.",
+                                           "Deals 7 damage to ALL enemies.") == (
+        {"Damage": ["7"]}, {}, {})
+
+
+def test_fallback_ignores_ordinals_when_counting_numbers():
+    """"the 3rd turn" is prose, not a value; counting it would make the text
+    look ambiguous and lose an otherwise recoverable number."""
+    assert localize.fallback_single_number("Deal {D} damage on the 3rd turn.",
+                                           "Deal 9 damage on the 3rd turn.") == (
+        {"D": ["9"]}, {}, {})
+
+
+def test_fallback_fills_every_occurrence_of_the_single_name():
+    got = localize.fallback_single_number("Deal {D} damage. Block {D}.",
+                                          "Deal 6 damage and block the same.")
+    assert got == ({"D": ["6", "6"]}, {}, {})
+
+
+@pytest.mark.parametrize("template, shipped, why", [
+    ("Deal {D} damage.", "Deals 7 damage 3 times.", "two numbers: ambiguous"),
+    ("Deal {D} damage.", "Deals damage.", "no number at all"),
+    ("Deal {D} damage, gain {B} Block.", "Something with 7 in it", "two names"),
+    ("{X:show:A|B}", "1", "a branch choice cannot be guessed"),
+    ("{N:cond:>1?a|b}", "1", "a cond cannot be guessed"),
+    ("{Chaos:only}", "1", "TEXT is unresolvable"),
+    ("{EnchantmentName}", "1", "a name is not a number"),
+    ("{}", "1", "a bare inner token has no owner here"),
+    ("Draw {N} {N:plural:{} card|{} cards}.", "Draw 4 cards.",
+     "nested tokens inside branches are too risky to guess"),
+    ("Deal {D} damage.", "Deal {broken", "unparseable shipped is still one number"),
+])
+def test_fallback_refuses_every_ambiguous_case(template, shipped, why):
+    assert localize.fallback_single_number(template, shipped) is None, why
+
+
+def test_fallback_allows_a_plural_with_plain_branches():
+    """The plural word carries no value of its own, so a lone {N} is still an
+    unambiguous assignment."""
+    assert localize.fallback_single_number(
+        "Draw {N} {N:diff():plural:card|cards}.", "Draw 4 cards.") == (
+        {"N": ["4"]}, {}, {})
+
+
+def test_fallback_ignores_fixed_icons_when_counting_names():
+    assert localize.fallback_single_number("Costs {X:energyIcons(1)}. Deal {D}.",
+                                           "Costs 1 Energy. Deal 8.") is None
+
+
+# ---------------------------------------------------------- Russian plurals
+
+@pytest.mark.parametrize("n, form", [
+    # form 0 = nominative singular (1 карта), 1 = genitive singular (2 карты),
+    # 2 = genitive plural (5 карт). Anchors are real Russian agreement.
+    (1, 0), (21, 0), (101, 0), (1001, 0),
+    (2, 1), (3, 1), (4, 1), (22, 1), (24, 1), (104, 1),
+    (0, 2), (5, 2), (9, 2), (10, 2),
+    (11, 2), (12, 2), (13, 2), (14, 2),   # the teens are the exception
+    (25, 2), (111, 2), (112, 2),
+])
+def test_plural_index_ru_follows_russian_agreement(n, form):
+    assert localize.plural_index_ru(n, 3) == form
+
+
+def test_plural_index_ru_is_sign_insensitive():
+    assert localize.plural_index_ru(-21, 3) == localize.plural_index_ru(21, 3)
+
+
+@pytest.mark.parametrize("n, expected", [(1, 0), (0, 1), (2, 1), (5, 1)])
+def test_plural_index_ru_degrades_to_english_rules_for_two_branches(n, expected):
+    assert localize.plural_index_ru(n, 2) == expected
+
+
+@pytest.mark.parametrize("n", [0, 1, 2, 7])
+def test_plural_index_ru_with_one_branch_always_picks_it(n):
+    assert localize.plural_index_ru(n, 1) == 0
+
+
+# ------------------------------------------------------------ needs_alignment
+
+@pytest.mark.parametrize("template, expected", [
+    ("Exhaust.", False),
+    ("Costs {X:energyIcons(2)}.", False),      # fixed icon needs no value
+    ("{singleStarIcon}", False),
+    ("Deal {D} damage.", True),
+    ("Costs {X:energyIcons()}.", True),
+    ("{X:show:A|B}", True),
+    ("Broken {", True),                        # unparseable: will fail anyway
+])
+def test_needs_alignment_identifies_templates_that_need_english_values(template, expected):
+    assert localize.needs_alignment(template) is expected
+
+
+# ------------------------------------------------------------------ rendering
+
+def _render(template, values=None, branches=None, hints=None, lang="de",
+            energy="Energie", star="Stern", ench_lookup=None):
+    r = localize.Renderer(values or {}, branches or {}, lang, energy, star,
+                          hints or {}, ench_lookup)
+    return r.render(template)
+
+
+def test_render_substitutes_values_into_a_translated_template():
+    assert _render("Verursache {D} Schaden.", {"D": ["9"]}) == "Verursache 9 Schaden."
+
+
+def test_render_strips_markup_from_translated_literals():
+    assert _render("Gewinne [gold]{B}[/gold] Block.", {"B": ["5"]}) == "Gewinne 5 Block."
+
+
+def test_render_consumes_repeated_values_in_order():
+    assert _render("{D} dann {D}.", {"D": ["3", "7"]}) == "3 dann 7."
+
+
+def test_render_reuses_the_last_value_when_a_template_repeats_a_token():
+    """A translation may mention a value more often than English did. Reusing
+    the last known value beats failing the whole entity."""
+    assert _render("{D} {D} {D}", {"D": ["4"]}) == "4 4 4"
+
+
+def test_render_places_the_icon_word_after_the_number():
+    assert _render("Kostet {C:energyIcons()}.", {"C": ["2"]}) == "Kostet 2 Energie."
+    assert _render("Kostet {S:starIcons()}.", {"S": ["3"]}) == "Kostet 3 Stern."
+
+
+def test_render_omits_the_space_before_icon_words_in_cjk():
+    """CJK_NOSPACE is keyed by the game's own locale folder ("jpn"), which is
+    what _build_all passes -- not the app locale code ("ja"). Feeding the app
+    code in would silently put a space back into every Japanese cost."""
+    assert _render("{C:energyIcons()}", {"C": ["2"]}, lang="jpn",
+                   energy="エナジー") == "2エナジー"
+    assert _render("{C:energyIcons()}", {"C": ["2"]}, lang="zhs",
+                   energy="能量") == "2能量"
+
+
+def test_render_treats_an_icon_after_a_digit_as_a_unit_not_a_second_number():
+    """The game writes "0[energy icon]" meaning "0 Energy". Rendering the icon
+    as its own "1" would turn a zero cost into "01 Energie"."""
+    assert _render("0{X:energyIcons(1)}", {}) == "0 Energie"
+    assert _render("0 {X:energyIcons(1)}", {}) == "0 Energie"
+    assert _render("0{X:energyIcons(1)}", {}, lang="jpn", energy="エナジー") == "0エナジー"
+
+
+def test_render_a_fixed_icon_greater_than_one_keeps_its_number():
+    assert _render("Kostet {X:energyIcons(2)}.", {}) == "Kostet 2 Energie."
+
+
+def test_render_single_star_icon_is_one_star():
+    assert _render("{singleStarIcon}", {}) == "1 Stern"
+
+
+def test_render_picks_the_plural_branch_from_the_number_not_from_english():
+    """The recorded English branch is a fallback only. German, Russian and the
+    rest must agree with the *value*, or "2 Karte" ships."""
+    tpl = "Ziehe {N} {N:diff():plural:Karte|Karten}."
+    assert _render(tpl, {"N": ["1"]}) == "Ziehe 1 Karte."
+    assert _render(tpl, {"N": ["2"]}) == "Ziehe 2 Karten."
+    assert _render(tpl, {"N": ["7"]}) == "Ziehe 7 Karten."
+
+
+def test_render_uses_russian_agreement_for_a_three_branch_plural():
+    tpl = "{N} {N:plural(ru):карта|карты|карт}"
+    assert _render(tpl, {"N": ["1"]}, lang="ru") == "1 карта"
+    assert _render(tpl, {"N": ["3"]}, lang="ru") == "3 карты"
+    assert _render(tpl, {"N": ["5"]}, lang="ru") == "5 карт"
+
+
+def test_a_three_branch_plural_uses_russian_rules_even_without_the_ru_marker():
+    tpl = "{N:plural:a|b|c}"
+    assert _render(tpl, {"N": ["1"]}) == "a"
+    assert _render(tpl, {"N": ["3"]}) == "b"
+    assert _render(tpl, {"N": ["5"]}) == "c"
+
+
+def test_render_treats_an_x_valued_plural_as_plural():
+    """X is the game's "variable amount" marker; it is never exactly one."""
+    assert _render("{N:plural:Karte|Karten}", {"N": ["X"]}) == "Karten"
+
+
+def test_render_falls_back_to_the_english_branch_when_there_is_no_number():
+    assert _render("{N:plural:Karte|Karten}", {}, {"N": [1]}) == "Karten"
+
+
+def test_render_expands_a_bare_inner_token_to_the_owning_value():
+    assert _render("{N:plural:eine Karte|{} Karten}", {"N": ["4"]}) == "4 Karten"
+
+
+def test_render_follows_the_recorded_branch_for_a_show_token():
+    tpl = "{X:show:Verbannen.|Behalten.}"
+    assert _render(tpl, {}, {"X": [0]}) == "Verbannen."
+    assert _render(tpl, {}, {"X": [1]}) == "Behalten."
+
+
+def test_render_consumes_show_branches_in_order_then_reuses_the_last():
+    """Once the recorded choices run out the last one repeats, so a translation
+    that mentions the token more often than English did still renders."""
+    assert _render("{X:show:a|b}{X:show:a|b}{X:show:a|b}", {}, {"X": [0, 1]}) == "abb"
+
+
+@pytest.mark.parametrize("op, thr, value, expected", [
+    (">", 1, "3", "viele"), (">", 1, "1", "eine"),
+    (">=", 2, "2", "viele"), (">=", 2, "1", "eine"),
+    ("<", 2, "1", "viele"), ("<", 2, "5", "eine"),
+    ("<=", 1, "1", "viele"), ("<=", 1, "9", "eine"),
+    ("==", 3, "3", "viele"), ("==", 3, "4", "eine"),
+])
+def test_render_evaluates_every_cond_operator(op, thr, value, expected):
+    tpl = "{N:cond:%s%d?viele|eine}" % (op, thr)
+    assert _render(tpl, {"N": [value]}) == expected
+
+
+def test_render_resolves_a_cond_from_the_many_hint_when_no_number_survived():
+    """English matched the plural branch, so the value is known to exceed one
+    even though the digit itself never appeared in the text."""
+    assert _render("{N:cond:>1?viele|eine}", {}, {}, {"N": "many"}) == "viele"
+
+
+def test_render_resolves_an_enchantment_name_through_the_lookup():
+    assert _render("Verzaubere mit {EnchantmentName}.",
+                   {"EnchantmentName": ["Ember"]},
+                   ench_lookup={"Ember": "Glut"}.get) == "Verzaubere mit Glut."
+
+
+@pytest.mark.parametrize("template, values, branches, hints, message", [
+    ("Deal {D}.", {}, {}, {}, "no value for D"),
+    ("{X:show:A|B}", {}, {}, {}, "no branch for X"),
+    ("{}", {}, {}, {}, "bare {} outside branch"),
+    ("{N:plural:a|b}", {}, {}, {}, "plural unresolved for N"),
+    ("{N:cond:>1?a|b}", {}, {}, {}, "cond unresolved for N"),
+    # a "many" hint only helps the > and >= directions
+    ("{N:cond:<5?a|b}", {}, {}, {"N": "many"}, "cond unresolved for N"),
+    ("{Chaos:only}", {}, {}, {}, "kind TEXT"),
+    ("{X:show:A|B}", {}, {"X": [5]}, {}, "branch idx out of range for X"),
+    ("{N:cond:<1?only}", {"N": ["9"]}, {}, {}, "cond branches"),
+    ("Broken {", {}, {}, {}, "parse"),
+])
+def test_render_fails_loudly_rather_than_emitting_broken_text(
+        template, values, branches, hints, message):
+    with pytest.raises(localize.RenderFail, match=message):
+        _render(template, values, branches, hints)
+
+
+def test_render_fails_when_an_enchantment_cannot_be_resolved():
+    with pytest.raises(localize.RenderFail, match="unresolved"):
+        _render("{EnchantmentName}", {"EnchantmentName": ["Unknown"]},
+                ench_lookup=lambda _t: None)
+
+
+def test_render_fails_when_an_inner_token_has_no_value():
+    with pytest.raises(localize.RenderFail, match="no inner value"):
+        _render("{N:plural:a|{} b}", {}, {"N": [1]})
+
+
+# ------------------------------------------------------------- render_text
+
+def test_render_text_collapses_newlines_and_whitespace():
+    assert localize.render_text("Zeile\neins   {D}", ({"D": ["2"]}, {}, {}),
+                                "de", "Energie", "Stern") == "Zeile eins 2"
+
+
+def test_render_text_rejects_an_empty_result():
+    """An empty overlay string would blank the description in the UI; failing
+    means the entity keeps its English text instead."""
+    with pytest.raises(localize.RenderFail, match="empty render"):
+        localize.render_text("", ({}, {}, {}), "de", "Energie", "Stern")
+
+
+@pytest.mark.parametrize("template", ["Gewinne @ Block.", "Gewinne [ Block."])
+def test_render_text_rejects_leftover_game_markup(template):
+    """This is the last line of defence: anything still carrying {}[]@ means a
+    token was not understood, and shipping it shows raw markup to the player."""
+    with pytest.raises(localize.RenderFail, match="residue"):
+        localize.render_text(template, ({}, {}, {}), "de", "Energie", "Stern")
+
+
+# ------------------------------------------------------------- resolve_key
+
+@pytest.mark.parametrize("key, catalog, expected", [
+    ("BASH", {"BASH"}, "BASH"),
+    ("BOTTLED_FLAME_EVENT", {"BOTTLED_FLAME"}, "BOTTLED_FLAME"),
+    ("SOME_QUEST", {"SOME"}, "SOME"),
+    ("SOME_TOKEN", {"SOME"}, "SOME"),
+    # an exact hit wins over stripping a suffix
+    ("SOME_EVENT", {"SOME_EVENT", "SOME"}, "SOME_EVENT"),
+    ("MISSING", {"BASH"}, None),
+    ("BASH_OTHER", {"BASH"}, None),
+])
+def test_resolve_key_falls_back_through_the_dual_suffixes(key, catalog, expected):
+    assert localize.resolve_key(key, catalog) == expected
+
+
+def test_load_returns_an_empty_table_when_the_game_lacks_it(monkeypatch):
+    monkeypatch.setattr(localize, "_LOC_DATA", {"deu": {"cards": {"A.title": "B"}}})
+    assert localize.load("deu", "cards") == {"A.title": "B"}
+    assert localize.load("deu", "relics") == {}
+    assert localize.load("klingon", "cards") == {}
+
+
+# ------------------------------------------------- full build, no game needed
+
+def _filler_cards(n=20):
+    """_build_all spot-checks 20 random cards, so the fixture needs at least
+    that many before any of the interesting ones are added."""
+    out = {}
+    for i in range(n):
+        out[f"FILLER_{i}.title"] = f"Filler {i}"
+        out[f"FILLER_{i}.description"] = "Gain {Block} Block."
+    return out
+
+
+ENG_CARDS = {
+    **_filler_cards(),
+    "BASH.title": "Bash",
+    "BASH.description": "Deal {Damage} damage. Apply {Vuln} Vulnerable.",
+    "STATIC.title": "Static",
+    "STATIC.description": "Exhaust.",                     # no alignment needed
+    "NOTRANS.title": "Untranslated",
+    "NOTRANS.description": "Deal {Damage} damage.",
+    "RESIDUE.title": "Residue",
+    "RESIDUE.description": "Deal {Damage} damage.",
+    "DRIFTED.title": "Drifted",
+    "DRIFTED.description": "Deal {Damage} damage.",       # wording drifted -> fallback
+    "MISALIGNED.title": "Misaligned",
+    "MISALIGNED.description": "Deal {Damage} damage and {Other} more.",
+    "RENDERFAIL.title": "Render Fail",
+    "RENDERFAIL.description": "Deal {Damage} damage.",
+    "NODESC.title": "No Description",                     # title only, no template
+    "PLAINNAME.title": "Plain Name",
+    "PLAINNAME.description": "Deal {Damage} damage.",     # no shipped English text
+    "SUFFIXED.title": "Suffixed",
+    "SUFFIXED.description": "Gain {Block} Block.",
+}
+
+DEU_CARDS = {
+    **{f"FILLER_{i}.title": f"Fuller {i}" for i in range(20)},
+    **{f"FILLER_{i}.description": "Gewinne {Block} Block." for i in range(20)},
+    "BASH.title": "Schmettern",
+    "BASH.description": "Verursache {Damage} Schaden. Wende {Vuln} Verwundbar an.",
+    "STATIC.title": "Statisch",
+    "STATIC.description": "Verbannen.",
+    # NOTRANS deliberately absent: not yet translated
+    "RESIDUE.title": "Kaputt {Damage}",                   # unrendered markup in a name
+    "RESIDUE.description": "Verursache {Damage} Schaden.",
+    "DRIFTED.title": "Abgewichen",
+    "DRIFTED.description": "Verursache {Damage} Schaden.",
+    "MISALIGNED.title": "Fehlausrichtung",
+    "MISALIGNED.description": "Verursache {Damage} Schaden.",
+    "RENDERFAIL.title": "Render Fehler",
+    "RENDERFAIL.description": "Verursache {Nirgends} Schaden.",   # unknown token
+    "NODESC.title": "Keine Beschreibung",
+    "PLAINNAME.title": "Schlichter Name",
+    "PLAINNAME.description": "Verursache {Damage} Schaden.",
+    "SUFFIXED.title": "Mit Suffix",
+    "SUFFIXED.description": "Gewinne {Block} Block.",
+}
+
+APP_CARDS = [
+    {"id": "CARD.BASH", "description": "Deal 8 damage. Apply 2 Vulnerable.",
+     "description_upgraded": "Deal 10 damage. Apply 3 Vulnerable."},
+    {"id": "CARD.STATIC", "description": "Exhaust."},
+    {"id": "CARD.NOTRANS", "description": "Deal 5 damage."},
+    {"id": "CARD.RESIDUE", "description": "Deal 5 damage."},
+    {"id": "CARD.DRIFTED", "description": "Deals 6 damage to ALL enemies."},
+    {"id": "CARD.MISALIGNED", "description": "Completely different wording."},
+    {"id": "CARD.RENDERFAIL", "description": "Deal 7 damage."},
+    {"id": "CARD.NODESC", "description": ""},
+    {"id": "CARD.PLAINNAME", "description": ""},
+    {"id": "CARD.SUFFIXED_EVENT", "description": "Gain 4 Block."},
+    {"id": "CARD.NOT_IN_CATALOG", "description": "Deal 1 damage."},
+]
+
+
+def _write_app_data(tmp_path):
+    """Write the shipped-English data files the builder aligns against.
+
+    These carry *rendered* English (what the wiki scrape produced); the
+    templates with the {tokens} live in the localization tables instead.
+    """
+    d = tmp_path / "data"
+    d.mkdir(parents=True)
+    payloads = {
+        "cards": APP_CARDS,
+        "relics": [
+            {"id": "RELIC.BURNING_BLOOD", "description": "Heal 3 HP."},
+            {"id": "RELIC.PLAIN", "description": "Does a thing."},
+        ],
+        "potions": [{"id": "POTION.FIRE", "description": "Deal 9 damage."}],
+        "enemies": [
+            {"id": "MONSTER.JAW_WORM"},
+            {"id": "BOSS.HEXAGHOST"},
+            {"id": "ENCOUNTER.THREE_LOUSE"},
+            {"id": "CREATURE.CULTIST"},        # no prefix match, bare name hit
+            {"id": "MONSTER.BROKEN"},          # localized name carries residue
+            {"id": "MONSTER.UNKNOWN"},         # not in the game's tables at all
+        ],
+        "events": [{"id": "EVENT.NEOW"}, {"id": "EVENT.MYSTERY"}],
+    }
+    for name, payload in payloads.items():
+        (d / f"{name}.json").write_text(json.dumps(payload), encoding="utf-8")
+    return d
+
+
+LOC_DATA = {
+    "eng": {
+        "cards": ENG_CARDS,
+        "relics": {"BURNING_BLOOD.title": "Burning Blood",
+                   "BURNING_BLOOD.description": "Heal {Heal} HP.",
+                   "PLAIN.title": "Plain", "PLAIN.description": "Does a thing."},
+        "potions": {"FIRE.title": "Fire Potion",
+                    "FIRE.description": "Deal {Dmg} damage."},
+        "monsters": {"JAW_WORM.name": "Jaw Worm", "HEXAGHOST.name": "Hexaghost",
+                     "CULTIST.name": "Cultist", "BROKEN.name": "Broken"},
+        "encounters": {"THREE_LOUSE.title": "Three Louses"},
+        "events": {"NEOW.title": "Neow"},
+        "static_hover_tips": {"ENERGY.title": "Energy", "STAR_COUNT.title": "Star"},
+        "enchantments": {"EMBER.title": "Ember", "EMBER.body": "not a title"},
+    },
+    "deu": {
+        "cards": DEU_CARDS,
+        "relics": {"BURNING_BLOOD.title": "Brennendes Blut",
+                   "BURNING_BLOOD.description": "Heile {Heal} LP.",
+                   "PLAIN.title": "Schlicht", "PLAIN.description": "Tut etwas."},
+        "potions": {"FIRE.title": "Feuertrank",
+                    "FIRE.description": "Verursache {Dmg} Schaden."},
+        "monsters": {"JAW_WORM.name": "Kieferwurm", "HEXAGHOST.name": "Hexageist",
+                     "CULTIST.name": "Kultist", "BROKEN.name": "Kaputt {X}"},
+        "encounters": {"THREE_LOUSE.title": "Drei Läuse"},
+        "events": {"NEOW.title": "Neow"},
+        "static_hover_tips": {"ENERGY.title": "Energie", "STAR_COUNT.title": "Stern"},
+        "enchantments": {"EMBER.title": "Glut"},
+    },
+}
+
+
+@pytest.fixture
+def built(tmp_path, monkeypatch):
+    """Run the whole overlay builder against fixtures, with no game present."""
+    monkeypatch.setattr(localize, "APP", _write_app_data(tmp_path))
+    monkeypatch.setattr(localize, "OUT", tmp_path / "content")
+    monkeypatch.setattr(localize, "LANGS", ["deu"])
+    monkeypatch.setattr(localize, "_LOC_DATA", LOC_DATA)
+    report = localize._build_all()
+    overlay = json.loads((tmp_path / "content" / "deu.json").read_text(encoding="utf-8"))
+    return report, overlay
+
+
+def test_build_writes_an_overlay_with_metadata(built):
+    _report, overlay = built
+    assert overlay["_meta"]["language_native"] == "Deutsch"
+    assert overlay["_meta"]["source"] == "official game localization"
+    assert set(overlay) >= {"cards", "relics", "potions", "enemies", "events"}
+
+
+def test_build_renders_a_card_with_values_recovered_from_english(built):
+    _report, overlay = built
+    entry = overlay["cards"]["CARD.BASH"]
+    assert entry["name"] == "Schmettern"
+    assert entry["description"] == "Verursache 8 Schaden. Wende 2 Verwundbar an."
+
+
+def test_build_renders_the_upgraded_description_from_its_own_english(built):
+    """Upgraded text is aligned separately; sharing the base values would ship
+    the unupgraded numbers on every upgraded card."""
+    _report, overlay = built
+    assert overlay["cards"]["CARD.BASH"]["description_upgraded"] == (
+        "Verursache 10 Schaden. Wende 3 Verwundbar an.")
+
+
+def test_build_translates_a_template_that_needs_no_alignment(built):
+    entry = built[1]["cards"]["CARD.STATIC"]
+    assert entry["name"] == "Statisch"
+    assert entry["description"] == "Verbannen."
+
+
+def test_build_uses_the_single_number_fallback_when_wording_drifted(built):
+    _report, overlay = built
+    assert overlay["cards"]["CARD.DRIFTED"]["description"] == "Verursache 6 Schaden."
+
+
+def test_build_resolves_a_suffixed_id_back_to_its_catalog_entry(built):
+    _report, overlay = built
+    assert overlay["cards"]["CARD.SUFFIXED_EVENT"]["description"] == "Gewinne 4 Block."
+
+
+@pytest.mark.parametrize("card_id, why", [
+    ("CARD.NOTRANS", "no localized title yet"),
+    ("CARD.RESIDUE", "localized name still carries template markup"),
+    ("CARD.MISALIGNED", "English could not be aligned"),
+    ("CARD.RENDERFAIL", "translated template needs a value English never gave"),
+    ("CARD.NOT_IN_CATALOG", "shipped id is not in this game build"),
+])
+def test_build_leaves_unresolvable_cards_in_english(built, card_id, why):
+    """Absence from the overlay is the fallback: knowledge.py then keeps the
+    English entity. Emitting a partial entry would show raw markup instead."""
+    _report, overlay = built
+    assert card_id not in overlay["cards"], why
+
+
+@pytest.mark.parametrize("card_id", ["CARD.NODESC", "CARD.PLAINNAME"])
+def test_build_ships_a_name_only_entry_when_the_description_cannot_be_built(
+        built, card_id):
+    _report, overlay = built
+    assert set(overlay["cards"][card_id]) == {"name"}
+
+
+def test_build_translates_relics_and_potions_too(built):
+    _report, overlay = built
+    assert overlay["relics"]["RELIC.BURNING_BLOOD"]["description"] == "Heile 3 LP."
+    assert overlay["relics"]["RELIC.PLAIN"]["description"] == "Tut etwas."
+    assert overlay["potions"]["POTION.FIRE"]["description"] == "Verursache 9 Schaden."
+
+
+@pytest.mark.parametrize("enemy_id, name", [
+    ("MONSTER.JAW_WORM", "Kieferwurm"),
+    ("BOSS.HEXAGHOST", "Hexageist"),
+    ("ENCOUNTER.THREE_LOUSE", "Drei Läuse"),
+    ("CREATURE.CULTIST", "Kultist"),
+])
+def test_build_maps_enemies_through_every_id_shape(built, enemy_id, name):
+    _report, overlay = built
+    assert overlay["enemies"][enemy_id] == {"name": name}
+
+
+def test_build_drops_enemies_whose_localized_name_has_residue(built):
+    _report, overlay = built
+    assert "MONSTER.BROKEN" not in overlay["enemies"]
+    assert "MONSTER.UNKNOWN" not in overlay["enemies"]
+
+
+def test_build_maps_events_and_skips_unknown_ones(built):
+    _report, overlay = built
+    assert overlay["events"] == {"EVENT.NEOW": {"name": "Neow"}}
+
+
+def test_build_report_counts_match_the_overlay(built):
+    report, overlay = built
+    counts, size, fail_ids = report["deu"]
+    assert counts["cards_ok"] == len(
+        [c for c in overlay["cards"].values() if "description" in c])
+    assert counts["cards_name_only"] == 2
+    assert counts["cards_upgraded"] == len(
+        [c for c in overlay["cards"].values() if "description_upgraded" in c])
+    assert counts["enemies_ok"] == 4
+    assert counts["events_ok"] == 1
+    assert size > 0
+    # each failure is reported with the reason it failed, not just an id
+    assert any("untranslated" in f for f in fail_ids)
+    assert any("name residue" in f for f in fail_ids)
+    assert any("eng align" in f for f in fail_ids)
+    assert any("render:" in f for f in fail_ids)
+
+
+def test_build_is_deterministic(tmp_path, monkeypatch):
+    """The builder seeds its own sampler; two runs of the same inputs must
+    produce byte-identical overlays or the data-release diff is noise."""
+    outputs = []
+    for run in ("a", "b"):
+        monkeypatch.setattr(localize, "APP", _write_app_data(tmp_path / run))
+        monkeypatch.setattr(localize, "OUT", tmp_path / run / "content")
+        monkeypatch.setattr(localize, "LANGS", ["deu"])
+        monkeypatch.setattr(localize, "_LOC_DATA", LOC_DATA)
+        localize._build_all()
+        outputs.append((tmp_path / run / "content" / "deu.json").read_bytes())
+    assert outputs[0] == outputs[1]
+
+
+def test_enchantment_names_are_localized_through_the_english_title_index(
+        tmp_path, monkeypatch):
+    """The lookup goes localized-title <- key <- English-title, so a card that
+    names an enchantment only renders when the whole chain resolves."""
+    app = _write_app_data(tmp_path)
+    (app / "cards.json").write_text(json.dumps([
+        {"id": "CARD.ENCHANTED", "description": "Enchant with Ember."},
+        {"id": "CARD.MISSING_ENCH", "description": "Enchant with Nowhere."},
+    ]), encoding="utf-8")
+    loc = json.loads(json.dumps(LOC_DATA))  # deep copy
+    for lang, name in (("eng", "Enchant with {EnchantmentName}."),
+                       ("deu", "Verzaubere mit {EnchantmentName}.")):
+        loc[lang]["cards"]["ENCHANTED.title"] = "Enchanted"
+        loc[lang]["cards"]["ENCHANTED.description"] = name
+        loc[lang]["cards"]["MISSING_ENCH.title"] = "Missing"
+        loc[lang]["cards"]["MISSING_ENCH.description"] = name
+    monkeypatch.setattr(localize, "APP", app)
+    monkeypatch.setattr(localize, "OUT", tmp_path / "content")
+    monkeypatch.setattr(localize, "LANGS", ["deu"])
+    monkeypatch.setattr(localize, "_LOC_DATA", loc)
+    localize._build_all()
+    overlay = json.loads((tmp_path / "content" / "deu.json").read_text(encoding="utf-8"))
+    assert overlay["cards"]["CARD.ENCHANTED"]["description"] == "Verzaubere mit Glut."
+    # an enchantment the game has no name for must not ship a half-rendered card
+    assert "CARD.MISSING_ENCH" not in overlay["cards"]
+
+
+def test_build_falls_back_to_english_icon_words(tmp_path, monkeypatch):
+    """A language whose static_hover_tips lack the icon titles still has to
+    render costs; falling back to "Energy"/"Star" beats failing every card."""
+    loc = json.loads(json.dumps(LOC_DATA))
+    del loc["deu"]["static_hover_tips"]
+    app = _write_app_data(tmp_path)
+    (app / "cards.json").write_text(json.dumps(
+        [{"id": "CARD.COSTLY", "description": "Costs 2 Energy."}]), encoding="utf-8")
+    for lang, tpl in (("eng", "Costs {C:energyIcons()}."),
+                      ("deu", "Kostet {C:energyIcons()}.")):
+        loc[lang]["cards"]["COSTLY.title"] = "Costly"
+        loc[lang]["cards"]["COSTLY.description"] = tpl
+    monkeypatch.setattr(localize, "APP", app)
+    monkeypatch.setattr(localize, "OUT", tmp_path / "content")
+    monkeypatch.setattr(localize, "LANGS", ["deu"])
+    monkeypatch.setattr(localize, "_LOC_DATA", loc)
+    localize._build_all()
+    overlay = json.loads((tmp_path / "content" / "deu.json").read_text(encoding="utf-8"))
+    assert overlay["cards"]["CARD.COSTLY"]["description"] == "Kostet 2 Energy."

--- a/tests/test_records_and_mods.py
+++ b/tests/test_records_and_mods.py
@@ -1,0 +1,387 @@
+"""Personal records, mod ingestion, and build-id carry-over across a bundle.
+
+Three things that share a property: each one degrades quietly rather than
+raising, so a break shows up as a wrong number or a missing entity on a page
+rather than as a failing request.
+
+- compute_records feeds the "hall of fame" panel. Every field is a max() or
+  min() over run history; picking the wrong extreme is invisible without an
+  assertion on the value.
+- _load_mods runs at KnowledgeBase construction, which happens at application
+  import. A hand-authored mod file is exactly where malformed input arrives,
+  and anything that escapes as an exception takes the whole server down before
+  a page can render.
+- _merge_local_build_ids protects hand-assigned patch mappings from being
+  discarded by a data-bundle install, which silently changes which runs count
+  as current-patch and therefore the win rates shown.
+"""
+import json
+
+import pytest
+
+from sts2.analytics import compute_records
+from sts2.models import PlayerProgress, RunFloor, RunHistory
+from sts2.updater import _merge_local_build_ids
+
+
+def _floor(n, ftype="monster", dmg=0, gold=0):
+    return RunFloor(floor=n, type=ftype, damage_taken=dmg, gold=gold,
+                    current_hp=50, max_hp=80)
+
+
+def _run(rid, win=False, asc=0, char="Ironclad", run_time=1200, deck=None,
+         floors=None):
+    return RunHistory(id=rid, character=char, win=win, ascension=asc,
+                      run_time=run_time, deck=deck or ["CARD.X"] * 20,
+                      floors=floors if floors is not None else [_floor(1)])
+
+
+# ----------------------------------------------------------------- records
+
+def test_no_runs_means_no_records():
+    assert compute_records([]) == {}
+
+
+def test_records_are_empty_but_present_without_a_single_win():
+    """A player with no wins still gets a records page; the win-only entries
+    are absent rather than showing a loss as a personal best."""
+    records = compute_records([_run("a"), _run("b")])
+    assert records["fastest_win"] is None
+    assert records["highest_ascension_win"] is None
+    assert records["biggest_deck"] is None
+    assert records["smallest_deck"] is None
+
+
+def test_fastest_win_is_the_shortest_winning_run():
+    runs = [_run("slow", win=True, run_time=9000),
+            _run("fast", win=True, run_time=1500),
+            _run("faster_but_lost", win=False, run_time=60)]
+    fastest = compute_records(runs)["fastest_win"]
+    assert fastest["run_id"] == "fast"
+    assert fastest["time"] == 1500
+
+
+def test_highest_ascension_win_ignores_losses():
+    runs = [_run("w", win=True, asc=8), _run("l", win=False, asc=20)]
+    best = compute_records(runs)["highest_ascension_win"]
+    assert best["ascension"] == 8 and best["run_id"] == "w"
+
+
+def test_deck_size_records_come_from_wins_only():
+    runs = [_run("big", win=True, deck=["CARD.X"] * 45),
+            _run("small", win=True, deck=["CARD.X"] * 12),
+            _run("huge_loss", win=False, deck=["CARD.X"] * 99)]
+    records = compute_records(runs)
+    assert records["biggest_deck"] == {"size": 45, "character": "Ironclad",
+                                       "run_id": "big"}
+    assert records["smallest_deck"]["size"] == 12
+
+
+def test_most_gold_is_the_richest_single_floor_across_every_run():
+    runs = [_run("a", floors=[_floor(1, gold=200), _floor(2, gold=50)]),
+            _run("b", floors=[_floor(3, gold=999)])]
+    assert compute_records(runs)["most_gold"] == {"gold": 999, "run_id": "b",
+                                                  "floor": 3}
+
+
+def test_most_gold_ignores_floors_that_recorded_none():
+    """gold == 0 usually means the floor simply did not record it, so it must
+    not win the record by being the only entry."""
+    runs = [_run("a", floors=[_floor(1, gold=0)])]
+    assert compute_records(runs)["most_gold"] is None
+
+
+def test_most_damage_floor_is_the_worst_single_floor():
+    runs = [_run("a", floors=[_floor(1, dmg=10), _floor(2, dmg=44)]),
+            _run("b", floors=[_floor(3, dmg=30)])]
+    worst = compute_records(runs)["most_damage_floor"]
+    assert worst == {"damage": 44, "floor": 2, "run_id": "a"}
+
+
+def test_flawless_bosses_counts_boss_floors_taking_no_damage():
+    runs = [_run("a", floors=[_floor(16, ftype="boss", dmg=0),
+                              _floor(33, ftype="boss", dmg=12),
+                              _floor(50, ftype="boss", dmg=0)]),
+            _run("b", floors=[_floor(5, ftype="elite", dmg=0)])]
+    assert compute_records(runs)["flawless_bosses"] == 2
+
+
+def test_longest_streak_comes_from_progress_not_run_history():
+    progress = PlayerProgress(character_stats={
+        "Ironclad": {"best_streak": 3},
+        "Silent": {"best_streak": 7},
+    })
+    streak = compute_records([_run("a")], progress)["longest_streak"]
+    assert streak == {"count": 7, "character": "Silent"}
+
+
+def test_a_zero_streak_is_not_a_record():
+    progress = PlayerProgress(character_stats={"Ironclad": {"best_streak": 0}})
+    assert compute_records([_run("a")], progress)["longest_streak"] is None
+
+
+def test_records_without_progress_report_no_streak():
+    assert compute_records([_run("a")])["longest_streak"] is None
+
+
+def test_per_character_breakdown_splits_wins_from_losses():
+    runs = [
+        _run("i1", win=True, char="Ironclad", asc=5, run_time=2000),
+        _run("i2", win=False, char="Ironclad"),
+        _run("s1", win=True, char="Silent", asc=12, run_time=800),
+    ]
+    per = compute_records(runs)["per_character"]
+    assert per["Ironclad"] == {"wins": 1, "losses": 1, "best_ascension": 5,
+                               "fastest": 2000}
+    assert per["Silent"]["best_ascension"] == 12
+
+
+def test_per_character_defaults_to_zero_for_a_character_never_won_with():
+    runs = [_run("d1", win=False, char="Defect")]
+    assert compute_records(runs)["per_character"]["Defect"] == {
+        "wins": 0, "losses": 1, "best_ascension": 0, "fastest": 0}
+
+
+# -------------------------------------------------------------------- mods
+
+@pytest.fixture
+def modded_kb(tmp_path, monkeypatch):
+    """Build a KnowledgeBase with MODS_DIR pointed at a temp directory."""
+    def _build(files: dict[str, str]):
+        mods = tmp_path / "mods"
+        mods.mkdir(exist_ok=True)
+        for name, content in files.items():
+            (mods / name).write_text(content, encoding="utf-8")
+        monkeypatch.setattr("sts2.knowledge.MODS_DIR", mods)
+        from sts2.knowledge import KnowledgeBase
+        return KnowledgeBase()
+    return _build
+
+
+def _mod(**sections):
+    return json.dumps({"mod_name": "Test Mod", **sections})
+
+
+def test_a_mod_adds_entities_marked_as_mod_sourced(modded_kb):
+    # deliberately not "CARD.MODDED" -- that is a real Defect card in the
+    # shipped data, so a mod using it is a genuine base conflict
+    kb = modded_kb({"m.json": _mod(cards=[
+        {"id": "CARD.SPIRESCOPE_TEST_MOD", "name": "Test Mod Card",
+         "character": "Ironclad", "cost": "1", "type": "Attack",
+         "rarity": "Common"}])})
+    card = next(c for c in kb.cards if c.id == "CARD.SPIRESCOPE_TEST_MOD")
+    assert card.source == "mod"
+
+
+def test_a_mod_cannot_overwrite_a_base_card(modded_kb, caplog):
+    """A mod that reuses a base id would silently replace shipped data."""
+    kb = modded_kb({"m.json": _mod(cards=[
+        {"id": "CARD.BASH", "name": "Hijacked", "character": "Ironclad",
+         "cost": "1", "type": "Attack", "rarity": "Common"}])})
+    assert next(c for c in kb.cards if c.id == "CARD.BASH").name != "Hijacked"
+    assert "conflicts with base" in caplog.text
+
+
+def test_mod_id_namespaces_entity_ids_so_two_mods_cannot_collide(modded_kb):
+    kb = modded_kb({
+        "a.json": json.dumps({"mod_name": "A", "mod_id": "alpha", "cards": [
+            {"id": "CARD.SHARED", "name": "From Alpha", "character": "Ironclad",
+             "cost": "1", "type": "Attack", "rarity": "Common"}]}),
+        "b.json": json.dumps({"mod_name": "B", "mod_id": "beta", "cards": [
+            {"id": "CARD.SHARED", "name": "From Beta", "character": "Ironclad",
+             "cost": "1", "type": "Attack", "rarity": "Common"}]}),
+    })
+    ids = {c.id for c in kb.cards if c.source == "mod"}
+    assert ids == {"mod:alpha:CARD.SHARED", "mod:beta:CARD.SHARED"}
+
+
+def test_an_already_namespaced_id_is_not_namespaced_twice(modded_kb):
+    kb = modded_kb({"a.json": json.dumps({
+        "mod_name": "A", "mod_id": "alpha", "cards": [
+            {"id": "mod:alpha:CARD.X", "name": "X", "character": "Ironclad",
+             "cost": "1", "type": "Attack", "rarity": "Common"}]})})
+    assert any(c.id == "mod:alpha:CARD.X" for c in kb.cards)
+
+
+def test_mods_add_relics_potions_and_enemies_too(modded_kb):
+    kb = modded_kb({"m.json": _mod(
+        relics=[{"id": "RELIC.MODDED", "name": "Modded Relic",
+                 "character": "Shared", "rarity": "Common"}],
+        potions=[{"id": "POTION.MODDED", "name": "Modded Potion",
+                  "rarity": "Common"}],
+        enemies=[{"id": "MONSTER.MODDED", "name": "Modded Monster",
+                  "act": ["1"], "type": "normal"}],
+    )})
+    assert any(r.id == "RELIC.MODDED" for r in kb.relics)
+    assert any(p.id == "POTION.MODDED" for p in kb.potions)
+    assert any(e.id == "MONSTER.MODDED" for e in kb.enemies)
+
+
+def test_a_duplicate_relic_or_potion_or_enemy_is_skipped(modded_kb, caplog):
+    base = modded_kb({})
+    existing_relic = base.relics[0].id
+    existing_potion = base.potions[0].id
+    kb = modded_kb({"m.json": _mod(
+        relics=[{"id": existing_relic, "name": "Hijacked",
+                 "character": "Shared", "rarity": "Common"}],
+        potions=[{"id": existing_potion, "name": "Hijacked",
+                  "rarity": "Common"}],
+    )})
+    assert next(r for r in kb.relics if r.id == existing_relic).name != "Hijacked"
+    assert next(p for p in kb.potions if p.id == existing_potion).name != "Hijacked"
+
+
+@pytest.mark.parametrize("content, why", [
+    ("{ not json", "unparseable"),
+    ("[1, 2, 3]", "valid JSON but a list, not an object"),
+    ('"just a string"', "valid JSON but a bare string"),
+    ("null", "valid JSON null"),
+])
+def test_a_malformed_mod_file_never_stops_startup(modded_kb, content, why):
+    """KnowledgeBase() runs at application import, so anything escaping here
+    takes the server down before a single page can render."""
+    kb = modded_kb({"bad.json": content})
+    assert kb.cards, why
+
+
+@pytest.mark.parametrize("section_value", ['"a string"', "123", "null", "{}"])
+def test_a_section_of_the_wrong_shape_is_ignored(modded_kb, section_value):
+    """A string here would iterate character by character and hand each one to
+    the namespacing helper, which then fails on .get()."""
+    kb = modded_kb({"m.json": '{"mod_name": "T", "cards": %s}' % section_value})
+    assert kb.cards
+
+
+def test_non_object_entries_inside_a_section_are_dropped(modded_kb, caplog):
+    kb = modded_kb({"m.json": json.dumps({"mod_name": "T", "cards": [
+        "not an object",
+        {"id": "CARD.GOOD", "name": "Good", "character": "Ironclad",
+         "cost": "1", "type": "Attack", "rarity": "Common"},
+    ]})})
+    assert any(c.id == "CARD.GOOD" for c in kb.cards)
+    assert "dropped 1 non-object" in caplog.text
+
+
+def test_a_malformed_record_is_skipped_without_losing_the_good_ones(
+        modded_kb, caplog):
+    kb = modded_kb({"m.json": json.dumps({"mod_name": "T", "cards": [
+        {"id": "CARD.NO_REQUIRED_FIELDS"},
+        {"id": "CARD.FINE", "name": "Fine", "character": "Ironclad",
+         "cost": "1", "type": "Attack", "rarity": "Common"},
+    ]})})
+    assert any(c.id == "CARD.FINE" for c in kb.cards)
+    assert not any(c.id == "CARD.NO_REQUIRED_FIELDS" for c in kb.cards)
+    assert "skipping malformed card" in caplog.text
+
+
+def test_no_mods_directory_is_not_an_error(tmp_path, monkeypatch):
+    monkeypatch.setattr("sts2.knowledge.MODS_DIR", tmp_path / "absent")
+    from sts2.knowledge import KnowledgeBase
+    assert KnowledgeBase().cards
+
+
+# ------------------------------------------------ build-id carry-over
+
+def _patches(path, entries):
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
+def test_hand_assigned_build_ids_survive_a_bundle_install(tmp_path):
+    """The bundle ships patches.json and wins for its own files, so without
+    this the /admin/patches assignments were discarded on every data update --
+    silently changing which runs count as current-patch."""
+    local = _patches(tmp_path / "local.json",
+                     [{"patch": "1.0", "build_ids": ["mine-1", "mine-2"]}])
+    staged = _patches(tmp_path / "staged.json",
+                      [{"patch": "1.0", "build_ids": ["official"]}])
+    _merge_local_build_ids(local, staged)
+    merged = json.loads(staged.read_text(encoding="utf-8"))
+    assert merged[0]["build_ids"] == ["official", "mine-1", "mine-2"]
+
+
+def test_a_build_id_already_in_the_bundle_is_not_duplicated(tmp_path):
+    local = _patches(tmp_path / "local.json",
+                     [{"patch": "1.0", "build_ids": ["shared"]}])
+    staged = _patches(tmp_path / "staged.json",
+                      [{"patch": "1.0", "build_ids": ["shared"]}])
+    _merge_local_build_ids(local, staged)
+    assert json.loads(staged.read_text(encoding="utf-8"))[0]["build_ids"] == ["shared"]
+
+
+def test_a_patch_with_no_local_assignments_is_left_alone(tmp_path):
+    local = _patches(tmp_path / "local.json", [{"patch": "1.0", "build_ids": []}])
+    staged = _patches(tmp_path / "staged.json",
+                      [{"patch": "2.0", "build_ids": ["official"]}])
+    _merge_local_build_ids(local, staged)
+    assert json.loads(staged.read_text(encoding="utf-8"))[0]["build_ids"] == ["official"]
+
+
+def test_a_bundle_entry_without_build_ids_gains_the_local_ones(tmp_path):
+    local = _patches(tmp_path / "local.json",
+                     [{"patch": "1.0", "build_ids": ["mine"]}])
+    staged = _patches(tmp_path / "staged.json", [{"patch": "1.0"}])
+    _merge_local_build_ids(local, staged)
+    assert json.loads(staged.read_text(encoding="utf-8"))[0]["build_ids"] == ["mine"]
+
+
+def test_non_string_build_ids_are_not_carried(tmp_path):
+    local = _patches(tmp_path / "local.json",
+                     [{"patch": "1.0", "build_ids": [1, None, "good"]}])
+    staged = _patches(tmp_path / "staged.json",
+                      [{"patch": "1.0", "build_ids": []}])
+    _merge_local_build_ids(local, staged)
+    assert json.loads(staged.read_text(encoding="utf-8"))[0]["build_ids"] == ["good"]
+
+
+def test_non_dict_entries_on_either_side_are_skipped(tmp_path):
+    local = _patches(tmp_path / "local.json",
+                     ["junk", {"patch": "1.0", "build_ids": ["mine"]}])
+    staged = _patches(tmp_path / "staged.json",
+                      ["junk", {"patch": "1.0", "build_ids": []}])
+    _merge_local_build_ids(local, staged)
+    assert json.loads(staged.read_text(encoding="utf-8"))[1]["build_ids"] == ["mine"]
+
+
+@pytest.mark.parametrize("local_body, staged_body", [
+    ("{ not json", '[{"patch": "1.0"}]'),
+    ('[{"patch": "1.0"}]', "{ not json"),
+    ('{"not": "a list"}', '[{"patch": "1.0"}]'),
+    ('[{"patch": "1.0"}]', '{"not": "a list"}'),
+])
+def test_unreadable_or_wrong_shaped_manifests_leave_the_bundle_untouched(
+        tmp_path, local_body, staged_body):
+    local = (tmp_path / "local.json")
+    local.write_text(local_body, encoding="utf-8")
+    staged = (tmp_path / "staged.json")
+    staged.write_text(staged_body, encoding="utf-8")
+    _merge_local_build_ids(local, staged)
+    assert staged.read_text(encoding="utf-8") == staged_body
+
+
+def test_a_missing_manifest_on_either_side_is_a_no_op(tmp_path):
+    staged = _patches(tmp_path / "staged.json", [{"patch": "1.0"}])
+    _merge_local_build_ids(tmp_path / "absent.json", staged)
+    assert json.loads(staged.read_text(encoding="utf-8")) == [{"patch": "1.0"}]
+    local = _patches(tmp_path / "local.json", [{"patch": "1.0"}])
+    _merge_local_build_ids(local, tmp_path / "absent.json")   # must not raise
+
+
+def test_an_unwritable_manifest_is_logged_not_raised(tmp_path, monkeypatch, caplog):
+    """This runs mid-install; raising here would abort a data update that has
+    already staged its files."""
+    local = _patches(tmp_path / "local.json",
+                     [{"patch": "1.0", "build_ids": ["mine"]}])
+    staged = _patches(tmp_path / "staged.json",
+                      [{"patch": "1.0", "build_ids": []}])
+
+    real_write = type(staged).write_text
+
+    def flaky(self, *a, **kw):
+        if self == staged:
+            raise OSError("read-only file system")
+        return real_write(self, *a, **kw)
+
+    monkeypatch.setattr(type(staged), "write_text", flaky)
+    _merge_local_build_ids(local, staged)
+    assert "Could not write merged patch manifest" in caplog.text

--- a/tests/test_run_comparison.py
+++ b/tests/test_run_comparison.py
@@ -1,0 +1,382 @@
+"""Ghost splits, prophecy predictions, rivalry diffs, and the POSIX fsync path.
+
+These four are small enough that a single test file keeps them together: each
+is a pure function over run history, and each had only a smoke test asserting
+that a mock was called -- so any of them could have returned a constant.
+
+The persist case at the bottom is here because the durability path it covers
+only runs on POSIX, and every developer machine on this project is Windows,
+where it is an unconditional early return.
+"""
+import os
+
+import pytest
+
+from sts2.ghost import compute_splits, find_ghost_run, ghost_summary
+from sts2.models import CurrentRun, RunFloor, RunHistory
+from sts2.prophecy import (
+    _find_danger_zone,
+    _generate_recommendation,
+    generate_prophecy,
+    grade_prophecy,
+)
+from sts2.rivalry import compare_seed_runs
+
+
+def _floor(n, hp=70, gold=100, pick=""):
+    return RunFloor(floor=n, type="monster", current_hp=hp, max_hp=80,
+                    gold=gold, card_picked=pick)
+
+
+def _run(rid, win=False, asc=5, char="Ironclad", floors=None, run_time=1200,
+         deck=None, seed="SEED1"):
+    return RunHistory(id=rid, character=char, win=win, ascension=asc, seed=seed,
+                      run_time=run_time, deck=deck or ["CARD.X"] * 15,
+                      floors=floors if floors is not None else [_floor(10)])
+
+
+# ------------------------------------------------------------ ghost selection
+
+def test_no_runs_with_this_character_means_no_ghost():
+    assert find_ghost_run("Silent", 5, [_run("a", char="Ironclad")]) is None
+
+
+def test_ghost_prefers_a_win_at_a_similar_ascension():
+    runs = [_run("far", win=True, asc=20), _run("near", win=True, asc=6)]
+    assert find_ghost_run("Ironclad", 5, runs).id == "near"
+
+
+def test_ghost_prefers_the_higher_ascension_among_close_wins():
+    runs = [_run("a5", win=True, asc=5), _run("a7", win=True, asc=7)]
+    assert find_ghost_run("Ironclad", 5, runs).id == "a7"
+
+
+def test_ghost_breaks_an_ascension_tie_on_the_faster_run():
+    runs = [_run("slow", win=True, asc=5, run_time=9000),
+            _run("fast", win=True, asc=5, run_time=1200)]
+    assert find_ghost_run("Ironclad", 5, runs).id == "fast"
+
+
+def test_ghost_falls_back_to_any_win_when_none_are_close():
+    """Ascension 20 against a fresh ascension-0 run is a poor comparison, but
+    it beats having no ghost at all."""
+    runs = [_run("distant", win=True, asc=20), _run("loss", win=False, asc=1)]
+    assert find_ghost_run("Ironclad", 0, runs).id == "distant"
+
+
+def test_ghost_falls_back_to_the_deepest_run_when_there_are_no_wins():
+    runs = [_run("shallow", floors=[_floor(5)]), _run("deep", floors=[_floor(38)])]
+    assert find_ghost_run("Ironclad", 5, runs).id == "deep"
+
+
+def test_no_wins_and_no_floors_means_no_ghost():
+    assert find_ghost_run("Ironclad", 5, [_run("empty", floors=[])]) is None
+
+
+# --------------------------------------------------------------- ghost splits
+
+def test_splits_against_a_missing_ghost_are_empty():
+    assert compute_splits(CurrentRun(active=True), None) == []
+
+
+def test_splits_against_a_ghost_with_no_floors_are_empty():
+    assert compute_splits(CurrentRun(active=True), _run("g", floors=[])) == []
+
+
+def test_splits_compare_hp_gold_and_deck_floor_by_floor():
+    ghost = _run("g", floors=[_floor(1, hp=70, gold=100),
+                              _floor(2, hp=60, gold=150, pick="CARD.A")])
+    current = _run("c", floors=[_floor(1, hp=75, gold=90),
+                                _floor(2, hp=50, gold=200, pick="CARD.B")])
+    splits = compute_splits(current, ghost)
+    assert [s["floor"] for s in splits] == [1, 2]
+    assert splits[0]["hp_delta"] == 5 and splits[0]["ahead"] is True
+    assert splits[0]["gold_delta"] == -10
+    assert splits[1]["hp_delta"] == -10 and splits[1]["ahead"] is False
+    assert splits[1]["gold_delta"] == 50
+    # both picked one card, so the deck sizes stay level
+    assert splits[1]["deck_delta"] == 0
+
+
+def test_splits_track_a_deck_that_grew_faster_than_the_ghosts():
+    ghost = _run("g", floors=[_floor(1), _floor(2)])
+    current = _run("c", floors=[_floor(1, pick="CARD.A"), _floor(2, pick="CARD.B")])
+    assert [s["deck_delta"] for s in compute_splits(current, ghost)] == [1, 2]
+
+
+def test_floors_the_ghost_never_reached_are_skipped():
+    ghost = _run("g", floors=[_floor(1)])
+    current = _run("c", floors=[_floor(1), _floor(2), _floor(3)])
+    assert [s["floor"] for s in compute_splits(current, ghost)] == [1]
+
+
+def test_a_current_run_without_floors_produces_no_splits():
+    assert compute_splits(CurrentRun(active=True), _run("g")) == []
+
+
+# -------------------------------------------------------------- ghost summary
+
+def test_summary_of_no_splits_is_nothing():
+    assert ghost_summary([]) is None
+
+
+@pytest.mark.parametrize("last_delta, status", [(5, "ahead"), (-5, "behind"), (0, "even")])
+def test_summary_status_reflects_the_latest_floor(last_delta, status):
+    splits = [{"hp_delta": 10, "gold_delta": 0},
+              {"hp_delta": last_delta, "gold_delta": 25}]
+    summary = ghost_summary(splits)
+    assert summary["status"] == status
+    assert summary["current_hp_delta"] == last_delta
+    assert summary["current_gold_delta"] == 25
+
+
+def test_summary_counts_floors_ahead_and_behind_and_averages_the_gap():
+    splits = [{"hp_delta": d, "gold_delta": 0} for d in (10, -4, 0, 6)]
+    summary = ghost_summary(splits)
+    assert summary["floors_ahead"] == 2
+    assert summary["floors_behind"] == 1
+    assert summary["avg_hp_delta"] == 3.0
+
+
+# ------------------------------------------------------------------- prophecy
+
+def test_prophecy_needs_five_comparable_runs():
+    result = generate_prophecy("Ironclad", 5, [_run(str(i)) for i in range(4)])
+    assert result["available"] is False
+    assert "have 4" in result["reason"]
+
+
+def test_prophecy_only_counts_runs_within_two_ascensions():
+    runs = [_run(str(i), asc=20) for i in range(10)]
+    assert generate_prophecy("Ironclad", 0, runs)["available"] is False
+
+
+def test_prophecy_win_probability_is_the_empirical_rate():
+    runs = [_run(str(i), win=i < 3) for i in range(10)]
+    prophecy = generate_prophecy("Ironclad", 5, runs)
+    assert prophecy["available"] is True
+    assert prophecy["win_probability"] == 30.0
+    assert prophecy["sample_size"] == 10
+
+
+def test_prophecy_reports_the_average_floor_reached():
+    runs = [_run(str(f), floors=[_floor(f)]) for f in (10, 20, 30, 40, 50)]
+    assert generate_prophecy("Ironclad", 5, runs)["avg_floor"] == 30.0
+
+
+def test_prophecy_average_floor_survives_runs_with_no_floors():
+    """max(..., 1) guards the divisor; without it this is a ZeroDivisionError
+    on a history of runs that never recorded a floor."""
+    runs = [_run(str(i), floors=[]) for i in range(5)]
+    assert generate_prophecy("Ironclad", 5, runs)["avg_floor"] == 0.0
+
+
+def test_danger_zone_needs_at_least_three_deaths():
+    assert _find_danger_zone([10, 12]) is None
+
+
+def test_danger_zone_bins_deaths_into_five_floor_ranges():
+    zone = _find_danger_zone([16, 17, 18, 19, 3])
+    assert zone["range"] == "15-19"
+    assert zone["deaths"] == 4
+    assert zone["percentage"] == 80
+
+
+def test_prophecy_carries_the_danger_zone_through():
+    runs = [_run(str(i), floors=[_floor(f)])
+            for i, f in enumerate((6, 7, 8, 9, 30))]
+    assert generate_prophecy("Ironclad", 5, runs)["danger_zone"]["range"] == "5-9"
+
+
+@pytest.mark.parametrize("wins, losses, needle", [
+    (5, 0, "winning consistently"),
+    (0, 5, None),          # handled by the early/late split below
+])
+def test_recommendation_covers_the_all_wins_and_all_losses_cases(
+        wins, losses, needle):
+    runs = [_run(f"w{i}", win=True) for i in range(wins)]
+    runs += [_run(f"l{i}", win=False) for i in range(losses)]
+    rec = _generate_recommendation(runs, "Ironclad")
+    if needle:
+        assert needle in rec
+    else:
+        assert rec
+
+
+def test_recommendation_for_repeated_early_deaths_talks_about_act_one():
+    runs = [_run(str(i), floors=[_floor(8)]) for i in range(5)]
+    assert "early survival" in _generate_recommendation(runs, "Ironclad")
+
+
+def test_recommendation_for_repeated_late_deaths_talks_about_scaling():
+    runs = [_run(str(i), floors=[_floor(35)]) for i in range(5)]
+    assert "scaling cards" in _generate_recommendation(runs, "Ironclad")
+
+
+def test_recommendation_calls_out_bloated_losing_decks():
+    runs = [_run("w", win=True, deck=["CARD.X"] * 20)]
+    runs += [_run(f"l{i}", deck=["CARD.X"] * 40) for i in range(4)]
+    rec = _generate_recommendation(runs, "Ironclad")
+    assert "more selective" in rec
+    assert "20 cards vs 40" in rec
+
+
+def test_recommendation_falls_through_to_generic_advice():
+    runs = [_run("w", win=True, deck=["CARD.X"] * 20),
+            _run("l", deck=["CARD.X"] * 21)]
+    assert "Study your winning runs" in _generate_recommendation(runs, "Ironclad")
+
+
+def test_grading_an_unavailable_prophecy_is_nothing():
+    assert grade_prophecy({"available": False}, _run("a")) is None
+
+
+def test_grading_reports_whether_the_run_beat_the_prediction():
+    prophecy = {"available": True, "avg_floor": 20.0, "win_probability": 30.0}
+    grade = grade_prophecy(prophecy, _run("a", floors=[_floor(35)]))
+    assert grade["actual_floor"] == 35
+    assert grade["beat_prediction"] is True
+    assert grade["beat_odds"] is False          # it was a loss
+
+
+def test_grading_flags_a_win_against_the_odds():
+    prophecy = {"available": True, "avg_floor": 20.0, "win_probability": 12.5}
+    grade = grade_prophecy(prophecy, _run("a", win=True, floors=[_floor(50)]))
+    assert grade["actual_win"] is True
+    assert grade["beat_odds"] is True
+
+
+def test_a_likely_win_that_lands_is_not_beating_the_odds():
+    prophecy = {"available": True, "avg_floor": 20.0, "win_probability": 80.0}
+    assert grade_prophecy(prophecy, _run("a", win=True))["beat_odds"] is False
+
+
+def test_grading_a_run_with_no_floors_reads_floor_zero():
+    prophecy = {"available": True, "avg_floor": 20.0, "win_probability": 30.0}
+    assert grade_prophecy(prophecy, _run("a", floors=[]))["actual_floor"] == 0
+
+
+# -------------------------------------------------------------------- rivalry
+
+class _StubKB:
+    @staticmethod
+    def id_to_name(cid):
+        return {"CARD.A": "Anger", "CARD.B": "Bash"}.get(cid, cid)
+
+
+def test_runs_on_different_seeds_cannot_be_compared():
+    result = compare_seed_runs(_run("a", seed="AAA"), _run("b", seed="BBB"))
+    assert "Seeds don't match" in result["error"]
+
+
+def test_rivalry_reports_a_differing_card_pick_by_name():
+    a = _run("a", floors=[_floor(1, pick="CARD.A")])
+    b = _run("b", floors=[_floor(1, pick="CARD.B")])
+    picks = compare_seed_runs(a, b, _StubKB())["card_diffs"]
+    assert picks == [{"floor": 1, "type": "card_pick",
+                      "yours": "Anger", "rival": "Bash"}]
+
+
+def test_rivalry_falls_back_to_card_ids_without_a_knowledge_base():
+    a = _run("a", floors=[_floor(1, pick="CARD.A")])
+    b = _run("b", floors=[_floor(1, pick="CARD.B")])
+    assert compare_seed_runs(a, b)["card_diffs"][0]["yours"] == "CARD.A"
+
+
+def test_rivalry_ignores_a_floor_where_only_one_player_picked():
+    a = _run("a", floors=[_floor(1, hp=70, pick="CARD.A")])
+    b = _run("b", floors=[_floor(1, hp=70, pick="")])
+    assert compare_seed_runs(a, b)["card_diffs"] == []
+
+
+def test_rivalry_ignores_the_same_pick_on_both_sides():
+    a = _run("a", floors=[_floor(1, pick="CARD.A")])
+    b = _run("b", floors=[_floor(1, pick="CARD.A")])
+    assert compare_seed_runs(a, b)["card_diffs"] == []
+
+
+def test_rivalry_reports_an_hp_gap_with_its_direction():
+    a = _run("a", floors=[_floor(1, hp=70)])
+    b = _run("b", floors=[_floor(1, hp=45)])
+    hp = [d for d in compare_seed_runs(a, b)["diffs"] if d["type"] == "hp"]
+    assert hp == [{"floor": 1, "type": "hp", "yours": 70, "rival": 45, "delta": 25}]
+
+
+def test_rivalry_skips_floors_the_rival_never_reached():
+    a = _run("a", floors=[_floor(1, hp=70), _floor(2, hp=60)])
+    b = _run("b", floors=[_floor(1, hp=50)])
+    assert {d["floor"] for d in compare_seed_runs(a, b)["diffs"]} == {1}
+
+
+def test_rivalry_summarises_both_results():
+    a = _run("a", win=True, floors=[_floor(50, hp=30)])
+    b = _run("b", win=False, floors=[_floor(22, hp=0)])
+    result = compare_seed_runs(a, b)
+    assert result["seed"] == "SEED1"
+    assert result["your_result"] == "win"
+    assert result["rival_result"] == "died floor 22"
+    assert result["your_floor"] == 50 and result["rival_floor"] == 22
+
+
+def test_rivalry_handles_runs_with_no_floors():
+    a = _run("a", floors=[])
+    b = _run("b", floors=[])
+    result = compare_seed_runs(a, b)
+    assert result["your_floor"] == 0 and result["rival_floor"] == 0
+    assert result["diffs"] == []
+
+
+# --------------------------------------------------- durability on POSIX
+
+def test_directory_fsync_is_skipped_on_windows(monkeypatch):
+    """os.open on a directory raises on Windows, so the whole call is a no-op
+    there; attempting it would turn a successful write into a reported failure.
+    """
+    from sts2 import persist
+    monkeypatch.setattr(persist.os, "name", "nt")
+    calls = []
+    monkeypatch.setattr(persist.os, "open", lambda *a, **k: calls.append(a))
+    persist._fsync_dir_target = None
+    persist._fsync_dir(os.getcwd())
+    assert calls == []
+
+
+def test_directory_fsync_commits_the_rename_on_posix(monkeypatch, tmp_path):
+    """The rename is only durably committed once the *directory* is synced.
+    This leg never runs on the maintainer's machine, so it is only ever
+    exercised here."""
+    from sts2 import persist
+    monkeypatch.setattr(persist.os, "name", "posix")
+    opened, synced, closed = [], [], []
+    monkeypatch.setattr(persist.os, "open", lambda p, f: opened.append(p) or 42)
+    monkeypatch.setattr(persist.os, "fsync", synced.append)
+    monkeypatch.setattr(persist.os, "close", closed.append)
+    persist._fsync_dir(tmp_path)
+    assert opened == [str(tmp_path)]
+    assert synced == [42] and closed == [42]
+
+
+def test_a_failed_directory_fsync_never_fails_the_write(monkeypatch, tmp_path):
+    from sts2 import persist
+    monkeypatch.setattr(persist.os, "name", "posix")
+
+    def boom(*_a, **_kw):
+        raise OSError("not a directory")
+
+    monkeypatch.setattr(persist.os, "open", boom)
+    persist._fsync_dir(tmp_path)          # must not raise
+
+
+def test_the_descriptor_is_closed_even_when_the_sync_fails(monkeypatch, tmp_path):
+    from sts2 import persist
+    monkeypatch.setattr(persist.os, "name", "posix")
+    closed = []
+    monkeypatch.setattr(persist.os, "open", lambda _p, _f: 7)
+    monkeypatch.setattr(persist.os, "close", closed.append)
+
+    def boom(_fd):
+        raise OSError("sync failed")
+
+    monkeypatch.setattr(persist.os, "fsync", boom)
+    persist._fsync_dir(tmp_path)
+    assert closed == [7], "a leaked descriptor on every failed sync"


### PR DESCRIPTION
## What

`sts2/localize.py` was **12%** covered in CI and accounted for **39% of all uncovered code** in the repo. The only test that exercised it ran against a real game install and skipped everywhere else, including CI.

That is the worst place in the app to have a hole. English descriptions never pass through this pipeline, so a game patch that reshapes a template silently ships half-rendered markup or a wrong number to every non-English player while the suite stays green.

It needs no game to test: of 970 lines only 16 touch the filesystem, and the parser, the English alignment pass and the renderer are pure text → text. `tests/test_localize_pipeline.py` drives all of them from fixture strings, including the full overlay build.

Template shapes in the fixtures were taken from the shipped English card, relic and potion descriptions of build 0.107.1, so they exercise forms that actually occur (NUM 881, PLURAL 173, ENERGY 106, SHOW 65, STAR 27, ENCH 3, COND 1) rather than invented ones.

## Coverage: 74% → 90.48% in CI

| Module | Before | After |
|---|---:|---:|
| `localize.py` | 12% | **94%** |
| `behavior.py` | 52% | **100%** |
| `graveyard.py` | 61% | **100%** |
| `config.py` | 69% | **98%** |
| `__main__.py` | 71% | **97%** |
| `fetcher.py` | 74% | **88%** |
| `sources.py` | 77% | **94%** |
| `app.py` | 81% | **92%** |
| `updater.py` | 82% | **91%** |
| `analytics.py` | 88% | **96%** |
| `knowledge.py` | 86% | **89%** |
| `ghost` / `rivalry` / `persist` | 71 / 79 / 81% | **100%** |
| `prophecy.py` | 80% | **97%** |

Most of the above was previously exercised only by mocks asserting `mock.called`, so each module could have returned a constant and stayed green.

`--cov-fail-under` moves **72 → 88**, raised in three steps and each time from a *measured* CI run rather than an estimate.

## Three bugs fixed, all found while covering the code

**1. The overlay invented upgraded card descriptions.** `_build_all` gave every no-alignment card an `up` variant whether or not English had upgraded text. `card_detail.html` renders an "Upgraded:" block whenever the field is present, so six cards — Apotheosis, Despair, Lantern Key, Sharp Edge, Wish, Reserves — showed translated players a section English readers never see, restating the base description back at them. Thirteen languages, so 78 entries.

Verified against a real German build off an installed game: all six clean, the 545 legitimate upgraded translations untouched, and nothing in the 608-card overlay claims an upgrade English does not have.

**2. A duplicate "Upgraded:" block.** Separately, 98 English and 120 German cards rendered an "Upgraded:" section identical to the description above it.

The obvious fix — dropping the field from the overlay — was measured and is **wrong**: `knowledge.py` skips absent overlay values, so the card falls back to the *English* upgraded string under a translated description. `CARD.ANOINTED` came out as a German description with `'Retain. Put every Rare card from your Draw Pile into your Hand. Exhaust.'` beneath it, across 148 fields.

Fixed in the template instead, with the guard `deck.js` already applies to its popover. Measured: 490 English and 425 German cards keep their block, and no card whose upgraded text genuinely differs is hidden.

**3. `log.debug("   ", mm)`** passed an argument to a format string with no placeholder, which raises inside `logging` whenever DEBUG is on and the token-name check has anything to report.

Also removed an unreachable guard in `detect_tilt` (`len(runs) >= 3` is checked above, and `_group_sessions` always returns at least one non-empty session for non-empty input).

## The measurement gap has closed

This repo carried a ~7-point laptop-vs-CI coverage gap. It was almost entirely `localize.py` reading the installed game — 87% where the game exists, 12% in CI. Now that it runs on fixtures, both environments agree to within a point. The only remaining local-only difference is `risk.py` + `diagnosis.py`, which are gitignored and absent from a CI checkout. The stale comment in `ci.yml` documenting the old gap has been rewritten.

## Two statistics validated against their definitions

Rather than against a recorded output, which would only pin whatever the code happened to do:

- `_consistency_index` against the closed form of the R/S statistic for a linear ramp: cumulative deviation is `S_k = k(k−n)/2`, so `R = n²/8` exactly and `S = √((n²−1)/12)`. Checked at n = 10, 20, 40, 100. (An initial guess that it approaches 1 was wrong — it is 0.773 at n=40 — and deriving it exactly is what caught that.)
- `plural_index_ru` against real Russian agreement, including the 11–14 exception: 1→0, 21→0, 101→0, 2/3/4→1, 22→1, 11/12/13/14→2, 111→2.

## Verification

- `pytest -q` — 1570 passed
- `pytest -q -m browser` — 15 passed (required check, invisible to a plain run)
- `mypy sts2` — clean
- `ruff check sts2/ tests/` — clean
- All 15 CI checks green on Linux (3.11/3.12/3.13), Windows and macOS

## Known, not addressed

The root cause behind bug 2 is upstream: the game's description templates omit the keyword prefixes (`Retain.`, `Innate.`, `Exhaust.`) that the wiki-derived English carries, because those live in card metadata. That affects base descriptions too, not only upgraded ones, and reconstructing them across 13 languages is a feature rather than a fix.

`routes.py` (87%) is the largest remaining coverage target.
